### PR TITLE
MCU heartbeat resilience: server-side write timeout + firmware bounds, liveness watchdog, task WDT panic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,13 @@ Both tools use the same environment variables: ``NEON_ORG``, ``NEON_KEY``, and `
 - Default location: `./machine_state/` (configurable via `MACHINE_STATE_DIR` env var)
 - File locking via `filelock` ensures thread-safe state updates
 - Enables server restarts without affecting running machines
+- Each persistence write is bounded by `STATE_SAVE_TIMEOUT_SEC` (2.0 s) via
+  `MachineState.save_cache()`. If a write exceeds the budget the request
+  handler returns HTTP 503 to the MCU so the firmware sees a clean error
+  instead of a slow-but-200 response. Lifetime per-machine timeouts are
+  exposed as the `mac_state_save_timeouts_total` Prometheus counter, and
+  every timeout where the per-machine count is `>= 2` posts a notification
+  to `SLACK_CONTROL_CHANNEL_ID`.
 
 ### Request Flow
 
@@ -148,7 +155,9 @@ Both tools use the same environment variables: ``NEON_ORG``, ``NEON_KEY``, and `
 ### API Endpoints
 
 **Machine APIs** (`/machine/*`):
-- `POST /machine/update`: Main endpoint for MCU state updates
+- `POST /machine/update`: Main endpoint for MCU state updates. Returns 503
+  with `{"error": "state save timeout"}` if persisting the resulting state
+  exceeds `STATE_SAVE_TIMEOUT_SEC`.
 - `POST /machine/lock/<machine_name>`: Lock out a machine
 - `POST /machine/unlock/<machine_name>`: Unlock a machine
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,12 +154,13 @@ Both tools use the same environment variables: ``NEON_ORG``, ``NEON_KEY``, and `
 
 ### API Endpoints
 
-**Machine APIs** (`/machine/*`):
-- `POST /machine/update`: Main endpoint for MCU state updates. Returns 503
-  with `{"error": "state save timeout"}` if persisting the resulting state
-  exceeds `STATE_SAVE_TIMEOUT_SEC`.
-- `POST /machine/lock/<machine_name>`: Lock out a machine
-- `POST /machine/unlock/<machine_name>`: Unlock a machine
+**Machine APIs** (mounted under the `/api` blueprint, so externally served
+as `/api/machine/*`):
+- `POST /api/machine/update`: Main endpoint for MCU state updates. Returns
+  503 with `{"error": "state save timeout"}` if persisting the resulting
+  state exceeds `STATE_SAVE_TIMEOUT_SEC`.
+- `POST /api/machine/lock/<machine_name>`: Lock out a machine
+- `POST /api/machine/unlock/<machine_name>`: Unlock a machine
 
 **Admin APIs** (`/api/*`):
 - `POST /api/reload-users`: Hot-reload users.json without restart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,13 +126,18 @@ Both tools use the same environment variables: ``NEON_ORG``, ``NEON_KEY``, and `
   `MachineState.save_cache()`. If a write exceeds the budget the request
   handler returns HTTP 503 to the MCU so the firmware sees a clean error
   instead of a slow-but-200 response. `save_cache()` is single-flight per
-  machine (subsequent calls fail-fast while a previous save is hung) so a
-  stuck disk cannot exhaust the thread pool. Lifetime per-machine
-  timeouts are exposed as the `mac_state_save_timeouts_total` Prometheus
-  counter; a Slack notification is posted to `SLACK_CONTROL_CHANNEL_ID`
-  *exactly once*, on the transition to 2 timeouts for a given machine
-  (subsequent timeouts during a sustained disk hang do not re-page;
-  monitor the Prometheus counter for ongoing trend).
+  machine: only one worker *thread* runs at a time. Concurrent callers
+  *join* the in-flight task (each waits up to `STATE_SAVE_TIMEOUT_SEC`
+  for it to complete) instead of spawning a second thread that would
+  also block on the same disk, so a stuck disk cannot exhaust the
+  thread pool. Brief overlap between requests succeeds without
+  counting; only callers whose own wait actually exceeds the budget
+  count as timeouts. Lifetime per-machine timeouts are exposed as the
+  `mac_state_save_timeouts_total` Prometheus counter; a Slack
+  notification is posted to `SLACK_CONTROL_CHANNEL_ID` *exactly once*,
+  on the transition to 2 timeouts for a given machine (subsequent
+  timeouts during a sustained disk hang do not re-page; monitor the
+  Prometheus counter for ongoing trend).
 
 ### Request Flow
 
@@ -163,8 +168,10 @@ as `/api/machine/*`):
 - `POST /api/machine/update`: Main endpoint for MCU state updates. Returns
   503 with `{"error": "state save timeout"}` if persisting the resulting
   state exceeds `STATE_SAVE_TIMEOUT_SEC`.
-- `POST /api/machine/lock/<machine_name>`: Lock out a machine
-- `POST /api/machine/unlock/<machine_name>`: Unlock a machine
+- `POST /api/machine/oops/<machine_name>`: Set the machine into Oops
+  (maintenance-needed) state. `DELETE` on the same path clears it.
+- `POST /api/machine/locked_out/<machine_name>`: Lock out a machine.
+  `DELETE` on the same path unlocks it.
 
 **Admin APIs** (`/api/*`):
 - `POST /api/reload-users`: Hot-reload users.json without restart

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,10 +125,14 @@ Both tools use the same environment variables: ``NEON_ORG``, ``NEON_KEY``, and `
 - Each persistence write is bounded by `STATE_SAVE_TIMEOUT_SEC` (2.0 s) via
   `MachineState.save_cache()`. If a write exceeds the budget the request
   handler returns HTTP 503 to the MCU so the firmware sees a clean error
-  instead of a slow-but-200 response. Lifetime per-machine timeouts are
-  exposed as the `mac_state_save_timeouts_total` Prometheus counter, and
-  every timeout where the per-machine count is `>= 2` posts a notification
-  to `SLACK_CONTROL_CHANNEL_ID`.
+  instead of a slow-but-200 response. `save_cache()` is single-flight per
+  machine (subsequent calls fail-fast while a previous save is hung) so a
+  stuck disk cannot exhaust the thread pool. Lifetime per-machine
+  timeouts are exposed as the `mac_state_save_timeouts_total` Prometheus
+  counter; a Slack notification is posted to `SLACK_CONTROL_CHANNEL_ID`
+  *exactly once*, on the transition to 2 timeouts for a given machine
+  (subsequent timeouts during a sustained disk hang do not re-page;
+  monitor the Prometheus counter for ongoing trend).
 
 ### Request Flow
 

--- a/docs/2026-05-05-mcu-lockup-analysis.md
+++ b/docs/2026-05-05-mcu-lockup-analysis.md
@@ -1,0 +1,259 @@
+# MCU Heartbeat Lockup Analysis — 2026-05-05
+
+## Incident summary
+
+On **2026-05-05 14:18:53 ET**, four ESPHome-based MAC ESP32 units —
+**Bronte**, **Grizzly Metal Lathe**, **Metal Mill**, and **Resaw** — all
+stopped checking in to `mac-server` within **31 seconds of one another**.
+The trigger was a server-side disk hang: one POST to
+`/api/machine/update` took **30.6 s** to return **HTTP 200**.
+
+After that single slow-but-successful request, all four MCUs sat
+locked up — still WiFi-associated to their UniFi APs (confirmed via
+per-MAC `unpoller_client_uptime_seconds`, zero drops across 23 h) but
+doing no application work — until each was power-cycled
+**~22 h 57 m later**.
+
+This document analyzes the ESPHome configs at
+`esphome-configs/2025.11.2/` to determine which component sends the
+heartbeat, why a single delayed-but-200 response leaves the firmware
+permanently locked up, and what concrete config or component changes
+would close the failure mode.
+
+## What sends the heartbeat
+
+`esphome-configs/2025.11.2/no-current-input.yaml`, the `interval:`
+block at **lines 377–430**, fires every 10 s (after a 30 s startup
+delay) and POSTs JSON to `mac_url`. The same `http_request.post` body
+is also duplicated in four other places:
+
+- `wifi.on_connect` (line 54)
+- `card_present.on_release` (line 161)
+- `oops_button.on_press` (line 228)
+- `wiegand.on_tag` (line 318)
+
+All five blocks share the same problematic shape: no `timeout`, no
+`on_error`, no failure counter, and a synchronous `http_request.post`
+that runs on the main loop task.
+
+## Timeout / retry / blocking behavior — as written
+
+- **No `timeout:` set** at the `http_request:` component (line 119 is
+  empty) and none on the action. ESPHome's default is **4.5 s**, but
+  per esp-idf / ESPHome docs and bug history this is the per-recv
+  socket timeout, not a true total-request bound — if the server
+  trickles bytes (or a TCP keepalive arrives) the timer keeps resetting
+  and the request can run far longer than 4.5 s. See ESPHome issues
+  [#4103](https://github.com/esphome/issues/issues/4103),
+  [#13669](https://github.com/esphome/esphome/issues/13669),
+  [#6682](https://github.com/esphome/issues/issues/6682).
+- **No `watchdog_timeout:` set.** On esp-idf this is what feeds (or
+  stops feeding) the task WDT during the transfer phase; without it
+  set, the WDT is fed throughout the whole HTTP exchange.
+- **No `on_error:` handler** on any of the five posts — only
+  `on_response`. A request that fails silently does nothing; nothing
+  increments a failure counter, nothing reboots.
+- **`http_request.post` is synchronous and runs on the main loop
+  task.** While the request is in flight the entire ESPHome `loop()`
+  is blocked — sensors don't update, the LCD doesn't refresh, no other
+  automations run. WiFi keeps its association because `wifi`/`lwIP`
+  runs in its own esp-idf task on the other core, which is exactly why
+  the UniFi `unpoller_client_uptime_seconds` saw zero drops.
+- **No application-level liveness watchdog.**
+  `wifi.reboot_timeout: 1min` only fires on a *disconnect*, and
+  `api.reboot_timeout: 0s` explicitly disables the native-API liveness
+  reboot. Nothing is configured to reboot the ESP32 if `loop()` stops
+  or if heartbeats stop succeeding while WiFi remains associated.
+- **No `CONFIG_ESP_TASK_WDT_*` sdkconfig overrides.** The esp-idf task
+  watchdog defaults to monitoring only the IDLE tasks; the loop task
+  is not subscribed, and the panic handler is not enabled.
+
+## Why a slow-but-200 response wedged the firmware
+
+Three failures stack to produce the 23-hour lockup:
+
+1. **30.6 s blocked loop.** The server stalled on disk but trickled
+   enough bytes that esp-idf's recv timeout never tripped, so
+   `esp_http_client_perform()` blocked the loop task for ~30 s.
+   Espressif explicitly documents this:
+   *"esp_http_client_perform blocks the task… when the server is down,
+   the HTTP request blocks the rest of the task for a very long time"*
+   (esp-idf [#12578](https://github.com/espressif/esp-idf/issues/12578)).
+2. **The "trickle" path is worse than a clean error.** Because the
+   response eventually returned **200** with a real body, no error
+   path ran and no reset was triggered — the firmware happily processed
+   the response and considered the cycle "successful." A 4.5 s clean
+   timeout would have surfaced via `on_error`… except there is no
+   `on_error` handler either.
+3. **Component left in a wedged state after the long exchange.** This
+   is the well-known symptom in ESPHome
+   [#6677](https://github.com/esphome/issues/issues/6677)
+   ("Device partially stops responding after HTTP Request failed") and
+   [#2501](https://github.com/esphome/issues/issues/2501)
+   ("http_request leaves ESP stuck"): display freezes, sensors stop
+   updating, ping/WiFi keep working, only a hard reboot restores it.
+   Maintainers' analysis: the http_request component sets an internal
+   error flag without recovering; in newer versions there is also an
+   unbounded read loop when `Content-Length` is missing or
+   `max_response_buffer_size` is set
+   ([#13669](https://github.com/esphome/esphome/issues/13669),
+   [#6682](https://github.com/esphome/issues/issues/6682)).
+   Once wedged, no watchdog kicks because (a) WiFi never disconnected,
+   (b) `api.reboot_timeout: 0s`, (c) the task WDT isn't watching the
+   loop. The device stays in this state indefinitely — exactly the
+   22 h 57 m observation.
+
+The "all four within 31 s" pattern is consistent with this: the
+server's single 30.6 s stall delivered the same poisoned response to
+all four units that happened to be in the middle of a heartbeat cycle,
+wedging each one.
+
+## Recommended changes (in priority order)
+
+### 1. Add an application-level liveness watchdog *(highest leverage; closes the failure mode)*
+
+Track the timestamp of the last successful POST, and reboot if it
+grows stale. Add new globals plus a watchdog interval:
+
+```yaml
+globals:
+  - id: last_ok_post_uptime
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+  - id: consecutive_post_failures
+    type: uint32_t
+    restore_value: false
+    initial_value: '0'
+
+interval:
+  - interval: 30s
+    startup_delay: 120s
+    then:
+      - lambda: |-
+          uint32_t now = (uint32_t) id(uptime_sensor).state;
+          uint32_t last = id(last_ok_post_uptime);
+          if (last == 0 || (now - last) > 90) {
+            ESP_LOGE("WDOG", "No successful POST in %us; rebooting", now - last);
+            App.safe_reboot();
+          }
+```
+
+In every `on_response` (where the body is parsed today) set
+`id(last_ok_post_uptime) = (uint32_t) id(uptime_sensor).state;` and
+reset `consecutive_post_failures` to 0. Add `on_error:` blocks (see §4)
+that increment `consecutive_post_failures` and call `App.safe_reboot()`
+once the count crosses a small threshold (e.g. `>= 3`).
+
+### 2. Bound any single POST to a few seconds
+
+```yaml
+http_request:
+  timeout: 5s
+  watchdog_timeout: 8s   # esp-idf only; caps the WDT-feed window during transfer
+```
+
+The `timeout` is the per-socket recv/send timeout (not bulletproof,
+see issues above) but is still strictly better than the 4.5 s default
+at correlated thresholds, because pairing it with `watchdog_timeout`
+provides a real ceiling: when transfer exceeds `watchdog_timeout` the
+task WDT stops being fed and (with the panic option below) will reset
+the chip.
+
+### 3. Enable the esp-idf task watchdog with panic
+
+```yaml
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP_TASK_WDT_TIMEOUT_S: "15"
+      CONFIG_ESP_TASK_WDT_EN: y
+      CONFIG_ESP_TASK_WDT_INIT: y
+      CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0: y
+      CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1: y
+      CONFIG_ESP_TASK_WDT_PANIC: y
+```
+
+With `..._PANIC: y` the device resets instead of just logging when the
+WDT fires. Combined with `watchdog_timeout: 8s`, a 15 s+ stuck
+transfer reboots automatically.
+
+### 4. Add `on_error` to every `http_request.post`
+
+```yaml
+on_error:
+  then:
+    - lambda: |-
+        id(consecutive_post_failures) += 1;
+        ESP_LOGW("HTTP", "POST failed; consec=%u", id(consecutive_post_failures));
+    - if:
+        condition:
+          lambda: 'return id(consecutive_post_failures) >= 3;'
+        then:
+          - lambda: 'App.safe_reboot();'
+```
+
+### 5. Eliminate the duplicated POST blocks
+
+The same ~50-line POST/parse block is copy-pasted five times. Move it
+into a `script:` (with `mode: restart` so a new event preempts a stuck
+one) and replace each occurrence with `script.execute: post_to_mac`.
+This dramatically reduces the chance that future fixes drift between
+the five copies.
+
+### 6. Re-enable a real ESPHome-API reboot fallback (or remove API entirely)
+
+`api.reboot_timeout: 0s` is fine *only* because there is no Home
+Assistant. Consider either:
+
+- removing the `api:` block entirely (one fewer task, one fewer thing
+  to wedge), or
+- keeping it but accepting that it is not a heartbeat watchdog for
+  *this* server — the application-level watchdog in §1 is the one that
+  matters.
+
+### 7. Server-side defensive change
+
+Independent of firmware: the original disk hang served a 30.6 s
+**200**. If the server detects that a write to its state directory
+exceeds e.g. 2 s, it should fail the request with a 503 instead of
+returning 200, so even the current firmware would hit `on_error` and
+(after fix §4) reboot.
+
+## Summary of root cause
+
+The firmware is missing every layer of defense that would have caught
+this:
+
+- no real total-request timeout,
+- no `on_error` handler,
+- no consecutive-failure reboot,
+- no liveness-of-loop watchdog,
+- no esp-idf task watchdog panic enabled,
+- and the only existing reboots (WiFi disconnect / API disconnect)
+  require the very signals that didn't fire in this incident.
+
+A 30 s response that returns **200** is therefore the worst possible
+outcome: it bypasses every error path that was available, and the
+http_request component has known wedge bugs
+([#6677](https://github.com/esphome/issues/issues/6677),
+[#2501](https://github.com/esphome/issues/issues/2501))
+that turn a one-time slow exchange into a permanent application
+lockup. Adding §1 + §2 + §3 + §4 above is the minimum change set that
+closes this.
+
+## References
+
+- [ESPHome #6677 — Device partially stops responding after "HTTP Request failed"](https://github.com/esphome/issues/issues/6677)
+- [ESPHome #2501 — http_request leaves ESP stuck if there is no internet connection](https://github.com/esphome/issues/issues/2501)
+- [ESPHome #6682 — http_request stucks on infinite loop when HTTP server does not send Content-Length](https://github.com/esphome/issues/issues/6682)
+- [ESPHome #4103 — Timeout on http_request not respected in all cases](https://github.com/esphome/issues/issues/4103)
+- [ESPHome #13669 — http_request read until timeout when max_response_buffer_size is set](https://github.com/esphome/esphome/issues/13669)
+- [ESPHome #6493 — watchdog non functional during stuck http request](https://github.com/esphome/issues/issues/6493)
+- [esp-idf #12578 — esp_http_client_perform slow / non connect](https://github.com/espressif/esp-idf/issues/12578)
+- [esp-idf #6364 — httpclient unhandled error causes call to not return](https://github.com/espressif/esp-idf/issues/6364)
+- [HTTP Request component docs (timeout / watchdog_timeout / on_error)](https://esphome.io/components/http_request/)
+- [ESP-IDF Watchdogs reference (CONFIG_ESP_TASK_WDT_*)](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/wdts.html)
+- [ESP HTTP Client API (esp_http_client_perform blocking semantics)](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/protocols/esp_http_client.html)

--- a/docs/features/mcu-heartbeat-resilience.md
+++ b/docs/features/mcu-heartbeat-resilience.md
@@ -435,7 +435,17 @@ verification, and live rollout pending.
   - **M4** — `esp32.framework.sdkconfig_options` configures the
     esp-idf task WDT with a 60 s timeout and `..._PANIC: y` for the
     catastrophic-hang fallback
-- **Milestone 5 — Acceptance:** ⏳ PENDING (docs already partially
-  updated as part of M1; remaining: full doc audit + run all `nox`
-  sessions + move file to `completed/`)
-- **Milestone 6 — Live Rollout:** ⏳ PENDING (post-merge)
+- **Milestone 5 — Acceptance:** ✅ COMPLETE (in this PR)
+  - `CLAUDE.md` updated with the State Persistence timeout behavior
+    and the 503 response on `/machine/update`.
+  - `docs/source/http-api.rst` gained a "State Save Timeout
+    (HTTP 503)" section and a paragraph in the Prometheus Metrics
+    section about `mac_state_save_timeouts_total`.
+  - All `nox` sessions pass: `tests` (97 % coverage), `mypy`,
+    `pre-commit`, `safety`, `docs`.
+  - The feature file is intentionally **not** moved to
+    `docs/features/completed/` in this PR because Milestone 6 (live
+    rollout) cannot complete until after merge; a follow-up commit
+    will move the file once live validation is signed off.
+- **Milestone 6 — Live Rollout:** ⏳ PENDING (post-merge — see
+  procedure above)

--- a/docs/features/mcu-heartbeat-resilience.md
+++ b/docs/features/mcu-heartbeat-resilience.md
@@ -1,0 +1,402 @@
+# MCU Heartbeat Resilience
+
+## Feature Description
+
+On 2026-05-05, four ESP32 MAC units (Bronte, Grizzly Metal Lathe, Metal
+Mill, Resaw) all stopped checking in within 31 seconds of one another
+after a server-side disk hang made one POST to `/api/machine/update`
+take 30.6 seconds to return HTTP 200. The units stayed WiFi-associated
+but did no application work for ~22h57m, until each was power-cycled.
+
+The full root-cause analysis is in
+[`docs/2026-05-05-mcu-lockup-analysis.md`](../2026-05-05-mcu-lockup-analysis.md).
+
+This feature implements every recommendation from that analysis, in a
+sequence that progressively raises the firmware's resilience to
+slow/wedged servers without ever interrupting an in-progress
+operation (e.g. a laser cut) except as a last-resort hardware
+fallback.
+
+## Goals
+
+1. **Eliminate the trigger at the source.** The MAC server must never
+   serve a slow-but-200 response: bound disk writes on
+   `/api/machine/update` and return HTTP 503 if a write exceeds a
+   small budget.
+2. **Bound any single POST on the MCU to a few seconds**, so the main
+   loop can never be blocked for >~8 seconds by a single request.
+3. **Detect heartbeat liveness on the MCU** and reboot if heartbeats
+   stop succeeding — but only when the relay is OFF, so an active cut
+   is never interrupted.
+4. **Provide a hardware-level last-resort fallback** (esp-idf task
+   WDT with panic) for catastrophic hangs that no software watchdog
+   can untangle.
+5. **Improve maintainability** of the firmware by deduplicating the
+   five copy-pasted `http_request.post` blocks in
+   `esphome-configs/2025.11.2/no-current-input.yaml`.
+
+## Non-Goals
+
+- Changing the MCU↔server protocol or response format.
+- Tightening `wifi.reboot_timeout` (the incident had healthy WiFi
+  throughout).
+- Re-enabling `api.reboot_timeout` (no Home Assistant in this
+  deployment).
+- Making the MCU recover *without* a reboot once wedged — once the
+  http_request component is in the wedge state described in ESPHome
+  issues #6677 / #2501, a reboot is the only known cure.
+
+## Implementation Plan
+
+### Overview
+
+Five layers of defense, applied in priority order so each milestone
+reduces risk monotonically:
+
+| Layer | Where | Reboot risk to active cut |
+|---|---|---|
+| §7 disk-write timeout → 503 | server | none |
+| §2 HTTP per-request timeout / watchdog_timeout | firmware | none |
+| §4 `on_error` failure tracking (no reboot) | firmware | none |
+| §5 dedupe POST blocks into a script | firmware | none |
+| §1 liveness watchdog **gated on relay OFF** | firmware | none under normal operation |
+| §3 esp-idf task WDT panic at 60 s | firmware | very rare; only on catastrophic hang |
+
+Files to modify:
+
+- `src/dm_mac/models/machine.py` (server-side: bound disk write time)
+- `src/dm_mac/views/machine.py` (server-side: catch timeout, return 503)
+- `esphome-configs/2025.11.2/no-current-input.yaml` (all firmware changes)
+- `tests/models/test_machine.py` and `tests/views/test_machine.py` (server-side tests)
+- Documentation: `CLAUDE.md`, `README.md`, `docs/source/` as needed
+
+The firmware file is *not* part of the Python test suite. Validation
+is by `esphome config no-current-input.yaml` (compile-check) and by
+on-device live test (described in Milestone 6).
+
+### Milestone 1: Server-Side Write Timeout (§7)
+
+**Commit prefix:** `mcu-heartbeat - 1.1` through `mcu-heartbeat - 1.4`
+
+The MAC server's `MachineState._save_cache()` writes a pickle file
+inside a `filelock`. If the underlying disk hangs (filesystem-level
+stall, full disk, bad SD card, etc.), the write can take tens of
+seconds and the request to `/api/machine/update` returns 200 only
+after the disk recovers. The MCU sees this as a successful but
+extremely slow response, which is the worst-case shape for the
+firmware (see analysis doc §3).
+
+The server should bound the time spent writing state and surface
+overruns to the MCU as HTTP 503 so the firmware sees a clean error
+and recovers via the next 10 s heartbeat.
+
+#### Task 1.1: Add `STATE_SAVE_TIMEOUT_SEC` constant and timeout-bounded save
+
+- In `src/dm_mac/models/machine.py`, add module-level constant
+  `STATE_SAVE_TIMEOUT_SEC = 2.0`.
+- Refactor `_save_cache()` to run the pickle dump under
+  `asyncio.wait_for(...)` (or run the synchronous body in a thread
+  with `asyncio.to_thread()` and `asyncio.wait_for`). The current
+  method is synchronous, so `MachineState.update()` (the async caller)
+  will need to invoke it via `await asyncio.to_thread(...)` wrapped in
+  `asyncio.wait_for`.
+- On `asyncio.TimeoutError`, log at ERROR level with the machine name
+  and re-raise a new exception class `StateSaveTimeoutError` so the
+  view layer can distinguish.
+
+#### Task 1.2: Plumb timeout into the view
+
+- In `src/dm_mac/views/machine.py`, the `/machine/update` handler
+  should catch `StateSaveTimeoutError` and return HTTP 503 with a JSON
+  body like `{"error": "state save timeout"}`. No state mutations
+  should be returned to the MCU on this path (i.e. don't claim the
+  relay is on if we couldn't persist that fact).
+- Add a Prometheus counter `mac_state_save_timeouts_total` (labeled by
+  machine) so we can alert on this from monitoring.
+- On the second and subsequent timeouts for a given machine (i.e.
+  when the per-machine counter transitions from 1 → 2 or higher),
+  send a Slack notification to `SLACK_CONTROL_CHANNEL_ID`. A single
+  one-off timeout is logged + counted but does not page; repeated
+  timeouts indicate a real disk problem.
+
+#### Task 1.3: Unit tests for timeout path
+
+- New tests in `tests/models/test_machine.py`:
+  - `test_save_cache_timeout`: monkeypatch `pickle.dump` (or the
+    `open()` call) to sleep longer than `STATE_SAVE_TIMEOUT_SEC`,
+    assert `StateSaveTimeoutError` is raised.
+  - `test_save_cache_succeeds_within_budget`: normal path completes
+    well under the budget.
+- New tests in `tests/views/test_machine.py`:
+  - `test_update_returns_503_on_save_timeout`: simulate a save timeout
+    and assert the response is HTTP 503 with the expected JSON body.
+  - `test_update_returns_200_on_normal_save`: regression check that
+    the happy path is unaffected.
+- Ensure the Prometheus counter increments by exactly 1 per timeout.
+
+#### Task 1.4: Documentation
+
+- Update `CLAUDE.md` "State Persistence" section to mention the
+  2 s save budget and 503 behavior on overrun.
+- Add a brief note in `docs/source/` (or wherever the API behavior is
+  documented) describing the new 503 response code.
+
+**Milestone completion criteria:**
+
+- All new tests pass.
+- All previously-passing tests still pass.
+- `nox -s tests`, `nox -s mypy`, `nox -s pre-commit` all pass.
+
+### Milestone 2: Firmware HTTP Timeouts and Failure Tracking (§2 + §4 + §5)
+
+**Commit prefix:** `mcu-heartbeat - 2.1` through `mcu-heartbeat - 2.4`
+
+These three changes are bundled because they share data (the new
+globals) and because §5 (deduplication) makes §2 and §4 trivially
+applied in one place rather than five.
+
+#### Task 2.1: Add globals for liveness state
+
+In `esphome-configs/2025.11.2/no-current-input.yaml`, add to
+`globals:`:
+
+```yaml
+- id: last_ok_post_uptime
+  type: uint32_t
+  restore_value: false
+  initial_value: '0'
+- id: consecutive_post_failures
+  type: uint32_t
+  restore_value: false
+  initial_value: '0'
+```
+
+#### Task 2.2: Bound HTTP requests with timeout + watchdog_timeout
+
+Update the `http_request:` block:
+
+```yaml
+http_request:
+  timeout: 5s
+  watchdog_timeout: 8s
+```
+
+`timeout` is the per-recv socket timeout (best-effort upper bound);
+`watchdog_timeout` (esp-idf only) is what feeds the task WDT during
+transfer and gives a true ceiling when paired with the WDT panic
+config in Milestone 4.
+
+#### Task 2.3: Deduplicate POST into a `script: mode: restart`
+
+The same ~50-line POST/parse block is currently copy-pasted 5 times
+(`interval`, `wifi.on_connect`, `card_present.on_release`,
+`oops_button.on_press`, `wiegand.on_tag`).
+
+- Add a `script:` named `post_to_mac` with `mode: restart` (so a fresh
+  trigger preempts a stuck one rather than queuing).
+- The script body contains the `http_request.post` with the JSON
+  builder, `on_response` (parse JSON, drive relay/display/LEDs/second
+  relay, **set `id(last_ok_post_uptime) = uptime` and reset
+  `consecutive_post_failures = 0`**), and an `on_error` handler that
+  increments `consecutive_post_failures` and logs at WARN.
+- Replace each of the 5 inline `http_request.post` blocks with
+  `- script.execute: post_to_mac`.
+- The `on_error` handler must NOT call `App.safe_reboot()` directly —
+  reboot logic lives in Milestone 3 and is gated on relay state.
+
+#### Task 2.4: Compile-check the firmware
+
+- Run `esphome config esphome-configs/2025.11.2/no-current-input.yaml`
+  (locally, against ESPHome 2025.11.2) to confirm the YAML still
+  compiles. Any secrets needed for compile-check should be stubbed in
+  a `secrets.yaml` example included only locally — do **not** commit
+  real secrets.
+- If `esphome` is not installed locally, document the manual
+  validation step for the human reviewer.
+
+**Milestone completion criteria:**
+
+- YAML compiles cleanly with `esphome config`.
+- All five trigger sites use `script.execute: post_to_mac`.
+- The script body has both `on_response` (success path) and
+  `on_error` (failure path).
+- All previously-passing Python tests still pass (these changes are
+  firmware-only, so no regression expected).
+
+### Milestone 3: Firmware Liveness Watchdog (Relay-State Gated) (§1)
+
+**Commit prefix:** `mcu-heartbeat - 3.1`
+
+#### Task 3.1: Add the watchdog interval
+
+Add a new entry to `interval:` (alongside the existing 10 s heartbeat):
+
+```yaml
+- interval: 30s
+  startup_delay: 120s
+  then:
+    - lambda: |-
+        uint32_t now = (uint32_t) id(uptime_sensor).state;
+        uint32_t last = id(last_ok_post_uptime);
+        uint32_t stale = (last == 0) ? now : (now - last);
+        bool relay_on = id(relay_output).state || id(relay2_output).state;
+        if (stale > 90 && !relay_on) {
+          ESP_LOGE("WDOG", "No successful POST in %us; relay off; rebooting", stale);
+          App.safe_reboot();
+        } else if (stale > 90 && relay_on) {
+          ESP_LOGW("WDOG", "No successful POST in %us; relay ON; deferring reboot", stale);
+          id(display_content) = "WARN: server\nlink stale";
+          id(my_display).print(id(display_content));
+        }
+```
+
+Notes:
+
+- 90 s threshold = ~9 missed 10 s heartbeats. Tune in live testing.
+- 120 s `startup_delay` keeps the watchdog from firing during boot
+  before the first successful POST has had a chance to land.
+- The check inspects **both** primary and second relay state — if
+  either is energized, the machine is in an active operation and
+  reboots are deferred.
+- `App.safe_reboot()` (not `App.reboot()`) lets ESPHome teardown run
+  cleanly first.
+
+**Milestone completion criteria:**
+
+- YAML compiles.
+- Manual review confirms the relay-state gate is correct.
+- All previously-passing Python tests still pass.
+
+### Milestone 4: esp-idf Task Watchdog Panic (§3)
+
+**Commit prefix:** `mcu-heartbeat - 4.1`
+
+#### Task 4.1: Add sdkconfig overrides
+
+In the `esp32:` block of
+`esphome-configs/2025.11.2/no-current-input.yaml`:
+
+```yaml
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_ESP_TASK_WDT_TIMEOUT_S: "60"
+      CONFIG_ESP_TASK_WDT_EN: y
+      CONFIG_ESP_TASK_WDT_INIT: y
+      CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0: y
+      CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1: y
+      CONFIG_ESP_TASK_WDT_PANIC: y
+```
+
+A 60 s timeout (vs. the 15 s in the original analysis) is deliberate:
+the task WDT cannot inspect relay state, so any panic-reboot will
+interrupt whatever the machine is doing. 60 s ensures this only
+triggers on truly catastrophic hangs that the gated watchdog in
+Milestone 3 cannot recover from.
+
+**Milestone completion criteria:**
+
+- YAML compiles.
+- All previously-passing Python tests still pass.
+
+### Milestone 5: Acceptance Criteria
+
+**Commit prefix:** `mcu-heartbeat - 5.1` through `mcu-heartbeat - 5.4`
+
+#### Task 5.1: Documentation
+
+- Update `CLAUDE.md`:
+  - Mention the new HTTP 503 response on `/api/machine/update` when
+    state save exceeds the budget.
+  - Note the new firmware liveness watchdog (90 s threshold, gated on
+    relay state) in any section that describes MCU behavior.
+- Update `README.md` if it documents the MCU/server protocol.
+- Update `docs/source/` if relevant API or operational pages exist.
+
+#### Task 5.2: Verify unit test coverage
+
+- `nox -s coverage -- report` must show coverage for the new
+  server-side timeout paths.
+- Add tests if any new branches are uncovered.
+
+#### Task 5.3: All nox sessions pass
+
+- `nox -s tests` — 100% passing.
+- `nox -s mypy` — clean.
+- `nox -s pre-commit` — clean.
+- `nox -s safety` — clean.
+
+#### Task 5.4: Move feature file to `completed/`
+
+- Move `docs/features/mcu-heartbeat-resilience.md` to
+  `docs/features/completed/mcu-heartbeat-resilience.md`.
+- Commit with `mcu-heartbeat - 5.4: feature complete`.
+
+### Milestone 6: Live Rollout & Validation
+
+**Commit prefix:** `mcu-heartbeat - 6.x` (only if hot-fixes needed)
+
+This milestone is performed by the human operator after Milestones 1–5
+land. No new code is expected; record outcomes in this document.
+
+Order of operations:
+
+1. **Deploy server-side fix (Milestone 1) to production first.**
+   Verify the MAC server still serves normal requests. Confirm the
+   `mac_state_save_timeouts_total` metric stays at zero under normal
+   load (any non-zero count indicates a real disk problem worth
+   investigating independently).
+2. **Flash one MCU first (suggested: Bronte)** with the firmware
+   changes from Milestones 2–4. Soak for at least 24 hours. Observe:
+   - Heartbeats arrive every ~10 s with no gaps.
+   - `last_ok_post_uptime` (visible in ESPHome logs at DEBUG) updates
+     on every successful POST.
+   - The watchdog interval logs no `WDOG` messages during normal
+     operation.
+3. **Induced-failure test on Bronte:**
+   - With no card inserted (relay off), stop `mac-server`.
+   - Confirm that within ~90–120 s the firmware logs a `WDOG` ERROR
+     and reboots cleanly.
+   - With a card inserted (relay on), stop `mac-server`.
+   - Confirm that the firmware logs a `WDOG` WARN, displays
+     `WARN: server\nlink stale` on the LCD, and does **not** reboot.
+   - Restart `mac-server`. Confirm normal heartbeats resume without a
+     reboot.
+4. **Flash the remaining three units** (Grizzly Metal Lathe, Metal
+   Mill, Resaw) once Bronte has 24+ hours of stable operation.
+5. **Record outcomes** in this feature document under
+   "Implementation Status" before moving the file to `completed/`.
+
+**Milestone completion criteria:**
+
+- All four units running the new firmware with stable heartbeats for
+  >7 days.
+- At least one induced-failure test (server stop) confirms the gated
+  watchdog reboots when relay is off and defers when relay is on.
+- No unexplained `WDOG` events in production.
+
+## Resolved Decisions
+
+1. **`STATE_SAVE_TIMEOUT_SEC = 2.0`** — confirmed; tunable later if
+   needed.
+2. **90 s firmware liveness threshold** — confirmed.
+3. **Slack alert** — fire when
+   `mac_state_save_timeouts_total > 1` for a given machine, so a
+   single transient timeout does not page anyone. Use the existing
+   `SLACK_CONTROL_CHANNEL_ID` (private admin channel) since this is
+   an operational issue, not a member-visible one.
+4. **Rollout shape** — single PR covering all milestones (overrides
+   the per-milestone approval gates in `docs/features/README.md`),
+   per explicit operator direction. Milestone commit prefixes are
+   still used for traceability inside the PR.
+5. **ESPHome compile-check** — install `esphome` locally and run
+   `esphome config` against the modified YAML before opening the PR.
+   If installation fails, flag for human handling.
+
+## Implementation Status
+
+**Status:** ⏳ PLANNED — awaiting human approval to begin implementation.
+
+(This section will be updated as Milestones complete.)

--- a/docs/features/mcu-heartbeat-resilience.md
+++ b/docs/features/mcu-heartbeat-resilience.md
@@ -397,6 +397,45 @@ Order of operations:
 
 ## Implementation Status
 
-**Status:** ⏳ PLANNED — awaiting human approval to begin implementation.
+**Status:** 🚧 IN PROGRESS — server changes (Milestone 1) and firmware
+changes (Milestones 2–4) implemented; documentation, full-suite
+verification, and live rollout pending.
 
-(This section will be updated as Milestones complete.)
+- **Milestone 1 — Server-Side Write Timeout:** ✅ COMPLETE
+  - `STATE_SAVE_TIMEOUT_SEC = 2.0` in `src/dm_mac/models/machine.py`
+  - `StateSaveTimeoutError` raised by new async
+    `MachineState.save_cache()` wrapper around the existing sync
+    `_save_cache()`
+  - All three view handlers (`/machine/update`, `/machine/oops`,
+    `/machine/locked_out`) catch the exception and return HTTP 503
+    with `{"error": "state save timeout"}`
+  - Per-machine `state_save_timeouts` counter persisted with the rest
+    of the pickle state
+  - `mac_state_save_timeouts_total` Prometheus counter exposed via a
+    new `LabeledCounterMetricFamily` helper
+  - Slack notification fired on every timeout where the per-machine
+    count crosses ≥ 2 (single transient stalls do not page)
+  - Tests: `TestAsyncSaveCache` (5 tests), 503 surfacing tests for
+    each of the three endpoints, prometheus output regenerated
+  - All `nox` sessions (`tests`, `mypy`, `pre-commit`) passing; total
+    coverage 97 %
+- **Milestones 2–4 — Firmware Changes:** ✅ COMPLETE
+  - `esphome-configs/2025.11.2/no-current-input.yaml` validates with
+    `esphome config` (ESPHome 2025.6.3 locally available)
+  - **M2** — `http_request: timeout: 5s` and `watchdog_timeout: 8s`;
+    five duplicated `http_request.post` blocks replaced with
+    `script.execute: post_to_mac`; new `script: mode: restart` is the
+    single source of truth for the POST and now has both
+    `on_response` (status-code-aware) and `on_error` handlers; new
+    `last_ok_post_uptime` and `consecutive_post_failures` globals
+  - **M3** — second `interval:` entry implements the liveness
+    watchdog (90 s threshold, 120 s startup_delay, gated on relay
+    state — reboots only when both relays are off, otherwise displays
+    `WARN: server\nlink stale` on the LCD)
+  - **M4** — `esp32.framework.sdkconfig_options` configures the
+    esp-idf task WDT with a 60 s timeout and `..._PANIC: y` for the
+    catastrophic-hang fallback
+- **Milestone 5 — Acceptance:** ⏳ PENDING (docs already partially
+  updated as part of M1; remaining: full doc audit + run all `nox`
+  sessions + move file to `completed/`)
+- **Milestone 6 — Live Rollout:** ⏳ PENDING (post-merge)

--- a/docs/source/http-api.rst
+++ b/docs/source/http-api.rst
@@ -8,6 +8,35 @@ with interactive documentation at ``/docs`` (Swagger UI) and ``/redocs`` (ReDoc)
 
 .. openapi:: openapi.json
 
+State Save Timeout (HTTP 503)
+-----------------------------
+
+The endpoints that mutate machine state — ``POST /api/machine/update``,
+``POST/DELETE /api/machine/oops/<machine_name>``, and
+``POST/DELETE /api/machine/locked_out/<machine_name>`` — bound the time
+spent persisting state to disk to ``STATE_SAVE_TIMEOUT_SEC`` (2.0
+seconds). If the underlying disk hangs and the write exceeds this
+budget, the handler returns:
+
+::
+
+    HTTP/1.1 503 Service Unavailable
+    Content-Type: application/json
+
+    {"error": "state save timeout"}
+
+This is the recommended path for the firmware to recover from a stuck
+disk on the server: the MCU sees a clean error, leaves its current
+relay state alone, and retries on its next 10-second heartbeat. Without
+this bound, a slow-but-eventually-successful 200 response can wedge the
+firmware via ESPHome ``http_request`` issues such as `#6677
+<https://github.com/esphome/issues/issues/6677>`_.
+
+Each timeout increments the per-machine ``mac_state_save_timeouts_total``
+Prometheus counter. When the lifetime per-machine count reaches 2 or
+more, a notification is posted to ``SLACK_CONTROL_CHANNEL_ID``; a single
+transient timeout is logged and counted but does not page.
+
 Second Relay Protocol Additions
 -------------------------------
 
@@ -51,5 +80,10 @@ metrics are emitted (one sample per machine, with labels ``machine_name``,
 
 These metrics are not emitted at all for machines without ``second_relay``,
 keeping cardinality minimal.
+
+The ``mac_state_save_timeouts_total`` counter (one sample per machine)
+exposes the lifetime count of writes to the per-machine pickle that
+exceeded ``STATE_SAVE_TIMEOUT_SEC``. See `State Save Timeout (HTTP 503)`_
+above for the firmware-facing behavior.
 
 See :py:mod:`dm_mac.views.prometheus` for details on the available metrics.

--- a/docs/source/http-api.rst
+++ b/docs/source/http-api.rst
@@ -23,6 +23,8 @@ The endpoints that mutate machine state —
 ``STATE_SAVE_TIMEOUT_SEC`` (2.0 seconds). If the underlying disk hangs
 and the write exceeds this budget, the handler returns:
 
+For ``POST /api/machine/update`` (firmware-facing):
+
 ::
 
     HTTP/1.1 503 Service Unavailable
@@ -30,17 +32,35 @@ and the write exceeds this budget, the handler returns:
 
     {"error": "state save timeout"}
 
-This is the recommended path for the firmware to recover from a stuck
-disk on the server: the MCU sees a clean error, leaves its current
-relay state alone, and retries on its next 10-second heartbeat. Without
-this bound, a slow-but-eventually-successful 200 response can wedge the
-firmware via ESPHome ``http_request`` issues such as `#6677
+For the admin endpoints (``POST/DELETE`` on ``/api/machine/oops/<name>``
+and ``/api/machine/locked_out/<name>``), the response body includes
+``action_applied: true`` to indicate that the requested state mutation
+took effect in memory even though persistence timed out — these
+actions also fire Slack notifications fire-and-forget, which cannot be
+rolled back, so the action *is* live and the next successful save will
+catch up:
+
+::
+
+    HTTP/1.1 503 Service Unavailable
+    Content-Type: application/json
+
+    {"error": "state save timeout", "action_applied": true}
+
+For the firmware-facing endpoint, the 503 response is the recommended
+path for the MCU to recover from a stuck disk on the server: it sees a
+clean error, leaves its current relay state alone, and retries on its
+next 10-second heartbeat. Without this bound, a slow-but-eventually
+successful 200 response can wedge the firmware via ESPHome
+``http_request`` issues such as `#6677
 <https://github.com/esphome/issues/issues/6677>`_.
 
 Each timeout increments the per-machine ``mac_state_save_timeouts_total``
-Prometheus counter. When the lifetime per-machine count reaches 2 or
-more, a notification is posted to ``SLACK_CONTROL_CHANNEL_ID``; a single
-transient timeout is logged and counted but does not page.
+Prometheus counter. A Slack notification is posted to
+``SLACK_CONTROL_CHANNEL_ID`` *exactly once*, on the transition from 1
+to 2 lifetime timeouts for a given machine; subsequent timeouts under a
+sustained disk hang do not re-page (operators monitoring the Prometheus
+counter can alert on continued growth).
 
 Second Relay Protocol Additions
 -------------------------------

--- a/docs/source/http-api.rst
+++ b/docs/source/http-api.rst
@@ -11,12 +11,17 @@ with interactive documentation at ``/docs`` (Swagger UI) and ``/redocs`` (ReDoc)
 State Save Timeout (HTTP 503)
 -----------------------------
 
-The endpoints that mutate machine state — ``POST /api/machine/update``,
-``POST/DELETE /api/machine/oops/<machine_name>``, and
-``POST/DELETE /api/machine/locked_out/<machine_name>`` — bound the time
-spent persisting state to disk to ``STATE_SAVE_TIMEOUT_SEC`` (2.0
-seconds). If the underlying disk hangs and the write exceeds this
-budget, the handler returns:
+The endpoints that mutate machine state —
+
+* ``POST /api/machine/update``,
+* ``POST /api/machine/oops/<machine_name>`` and
+  ``DELETE /api/machine/oops/<machine_name>``,
+* ``POST /api/machine/locked_out/<machine_name>`` and
+  ``DELETE /api/machine/locked_out/<machine_name>``
+
+— bound the time spent persisting state to disk to
+``STATE_SAVE_TIMEOUT_SEC`` (2.0 seconds). If the underlying disk hangs
+and the write exceeds this budget, the handler returns:
 
 ::
 

--- a/docs/source/http-api.rst
+++ b/docs/source/http-api.rst
@@ -36,9 +36,9 @@ For the admin endpoints (``POST/DELETE`` on ``/api/machine/oops/<name>``
 and ``/api/machine/locked_out/<name>``), the response body includes
 ``action_applied: true`` to indicate that the requested state mutation
 took effect in memory even though persistence timed out — these
-actions also fire Slack notifications fire-and-forget, which cannot be
-rolled back, so the action *is* live and the next successful save will
-catch up:
+actions also send Slack notifications in a fire-and-forget fashion,
+which cannot be rolled back, so the action *is* live and the next
+successful save will catch up:
 
 ::
 

--- a/esphome-configs/2025.11.2/no-current-input.yaml
+++ b/esphome-configs/2025.11.2/no-current-input.yaml
@@ -31,6 +31,18 @@ esp32:
   board: esp32dev
   framework:
     type: esp-idf
+    # Task watchdog: catastrophic-hang fallback only. The 60 s timeout is
+    # intentionally generous so this does NOT interrupt an in-progress
+    # operation (e.g. a laser cut) when the application-level liveness
+    # watchdog (interval below) can recover; this only fires when the loop
+    # task itself is so wedged that no software watchdog can run.
+    sdkconfig_options:
+      CONFIG_ESP_TASK_WDT_TIMEOUT_S: "60"
+      CONFIG_ESP_TASK_WDT_EN: y
+      CONFIG_ESP_TASK_WDT_INIT: y
+      CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU0: y
+      CONFIG_ESP_TASK_WDT_CHECK_IDLE_TASK_CPU1: y
+      CONFIG_ESP_TASK_WDT_PANIC: y
 
 # Enable logging
 logger:
@@ -53,6 +65,49 @@ wifi:
   reboot_timeout: "1min"
   on_connect:
     then:
+      - script.execute: post_to_mac
+
+globals:
+  - id: display_content
+    type: std::string
+    restore_value: False
+    max_restore_data_length: 34
+    initial_value: '"Connecting to\nWiFi"'
+  - id: rfid_tag
+    type: std::string
+    restore_value: False
+    max_restore_data_length: 34
+    initial_value: '""'
+  # Uptime seconds at which the most recent POST to mac_url returned 200
+  # (and was successfully parsed). Used by the liveness watchdog below.
+  - id: last_ok_post_uptime
+    type: uint32_t
+    restore_value: False
+    initial_value: '0'
+  # Count of consecutive failed POSTs since the last success. Used to
+  # surface persistent server-side problems on the LCD/log without
+  # rebooting the device while a relay is energized.
+  - id: consecutive_post_failures
+    type: uint32_t
+    restore_value: False
+    initial_value: '0'
+
+http_request:
+  # Bound any single POST to a few seconds. `timeout` is the per-recv
+  # socket timeout (best-effort upper bound); `watchdog_timeout` (esp-idf)
+  # caps the WDT-feed window during transfer and gives a real ceiling
+  # when paired with CONFIG_ESP_TASK_WDT_PANIC=y above.
+  timeout: 5s
+  watchdog_timeout: 8s
+
+# Single source of truth for the POST to mac_url. mode: restart so a fresh
+# trigger preempts a stuck one rather than queuing. Drives the relay,
+# display, oops LED, status LED, and second relay from the JSON response.
+# Tracks success/failure for the liveness watchdog interval below.
+script:
+  - id: post_to_mac
+    mode: restart
+    then:
       - http_request.post:
           url: !secret mac_url
           request_headers:
@@ -70,53 +125,53 @@ wifi:
           on_response:
             then:
               - lambda: |-
-                  json::parse_json(body, [](JsonObject root) -> bool {
-                      if ( root["relay"]) {
-                        ESP_LOGI("RELAY", "Turn relay on");
-                        id(relay_output).turn_on();
-                      } else {
-                        ESP_LOGI("RELAY", "Turn relay off");
-                        id(relay_output).turn_off();
-                      }
-                      std::string dcontent = root["display"];
-                      id(display_content) = dcontent;
-                      id(my_display).print(dcontent);
-                      if ( root["oops_led"]) {
-                        ESP_LOGI("OOPS", "Turn oops LED on");
-                        id(oops_led).turn_on();
-                      } else {
-                        ESP_LOGI("OOPS", "Turn oops LED off");
-                        id(oops_led).turn_off();
-                      }
-                      auto call = id(status_led).turn_on();
-                      float brightness = root["status_led_brightness"];
-                      call.set_brightness(brightness);
-                      call.set_rgb(root["status_led_rgb"][0], root["status_led_rgb"][1], root["status_led_rgb"][2]);
-                      call.perform();
-                      bool sr_state = root["second_relay"] | false;
-                      if ( sr_state) {
-                        ESP_LOGI("RELAY2", "Turn second relay on");
-                        id(relay2_output).turn_on();
-                      } else {
-                        ESP_LOGI("RELAY2", "Turn second relay off");
-                        id(relay2_output).turn_off();
-                      }
-                      return true;
-                  });
-
-globals:
-  - id: display_content
-    type: std::string
-    restore_value: False
-    max_restore_data_length: 34
-    initial_value: '"Connecting to\nWiFi"'
-  - id: rfid_tag
-    type: std::string
-    restore_value: False
-    max_restore_data_length: 34
-    initial_value: '""'
-
-http_request:
+                  if (status_code >= 200 && status_code < 300) {
+                    json::parse_json(body, [](JsonObject root) -> bool {
+                        if ( root["relay"]) {
+                          ESP_LOGI("RELAY", "Turn relay on");
+                          id(relay_output).turn_on();
+                        } else {
+                          ESP_LOGI("RELAY", "Turn relay off");
+                          id(relay_output).turn_off();
+                        }
+                        std::string dcontent = root["display"];
+                        id(display_content) = dcontent;
+                        id(my_display).print(dcontent);
+                        if ( root["oops_led"]) {
+                          ESP_LOGI("OOPS", "Turn oops LED on");
+                          id(oops_led).turn_on();
+                        } else {
+                          ESP_LOGI("OOPS", "Turn oops LED off");
+                          id(oops_led).turn_off();
+                        }
+                        auto call = id(status_led).turn_on();
+                        float brightness = root["status_led_brightness"];
+                        call.set_brightness(brightness);
+                        call.set_rgb(root["status_led_rgb"][0], root["status_led_rgb"][1], root["status_led_rgb"][2]);
+                        call.perform();
+                        bool sr_state = root["second_relay"] | false;
+                        if ( sr_state) {
+                          ESP_LOGI("RELAY2", "Turn second relay on");
+                          id(relay2_output).turn_on();
+                        } else {
+                          ESP_LOGI("RELAY2", "Turn second relay off");
+                          id(relay2_output).turn_off();
+                        }
+                        return true;
+                    });
+                    id(last_ok_post_uptime) = (uint32_t) id(uptime_sensor).state;
+                    id(consecutive_post_failures) = 0;
+                  } else {
+                    id(consecutive_post_failures) += 1;
+                    ESP_LOGW("HTTP", "Non-2xx response %d; consec=%u",
+                             status_code, id(consecutive_post_failures));
+                  }
+          on_error:
+            then:
+              - lambda: |-
+                  id(consecutive_post_failures) += 1;
+                  ESP_LOGW("HTTP", "POST failed (network/timeout); consec=%u",
+                           id(consecutive_post_failures));
 
 i2c:
   sda: GPIO22
@@ -158,56 +213,7 @@ binary_sensor:
             id(rfid_tag) = "";
             id(display_content) = "Please insert\naccess card";
             id(my_display).print("Please insert\naccess card");
-        - http_request.post:
-            url: !secret mac_url
-            request_headers:
-              Content-Type: application/json
-            json: |-
-              root["machine_name"] = App.get_name().c_str();
-              root["oops"] = id(oops_button).state;
-              root["rfid_value"] = id(rfid_tag);
-              root["uptime"] = id(uptime_sensor).state;
-              root["wifi_signal_db"] = id(wifi_signal_db).state;
-              root["wifi_signal_percent"] = id(wifi_signal_percent).state;
-              root["internal_temperature_c"] = id(internal_temperature_c).state;
-              root["second_relay_state"] = id(relay2_output).state;
-            capture_response: true
-            on_response:
-              then:
-                - lambda: |-
-                    json::parse_json(body, [](JsonObject root) -> bool {
-                        if ( root["relay"]) {
-                          ESP_LOGI("RELAY", "Turn relay on");
-                          id(relay_output).turn_on();
-                        } else {
-                          ESP_LOGI("RELAY", "Turn relay off");
-                          id(relay_output).turn_off();
-                        }
-                        std::string dcontent = root["display"];
-                        id(display_content) = dcontent;
-                        id(my_display).print(dcontent);
-                        if ( root["oops_led"]) {
-                          ESP_LOGI("OOPS", "Turn oops LED on");
-                          id(oops_led).turn_on();
-                        } else {
-                          ESP_LOGI("OOPS", "Turn oops LED off");
-                          id(oops_led).turn_off();
-                        }
-                        auto call = id(status_led).turn_on();
-                        float brightness = root["status_led_brightness"];
-                        call.set_brightness(brightness);
-                        call.set_rgb(root["status_led_rgb"][0], root["status_led_rgb"][1], root["status_led_rgb"][2]);
-                        call.perform();
-                        bool sr_state = root["second_relay"] | false;
-                        if ( sr_state) {
-                          ESP_LOGI("RELAY2", "Turn second relay on");
-                          id(relay2_output).turn_on();
-                        } else {
-                          ESP_LOGI("RELAY2", "Turn second relay off");
-                          id(relay2_output).turn_off();
-                        }
-                        return true;
-                    });
+        - script.execute: post_to_mac
 
   - platform: gpio
     pin:
@@ -225,56 +231,7 @@ binary_sensor:
         - lambda: |-
             id(display_content) = "OOPS!";
             id(my_display).print("OOPS!");
-        - http_request.post:
-            url: !secret mac_url
-            request_headers:
-              Content-Type: application/json
-            json: |-
-              root["machine_name"] = App.get_name().c_str();
-              root["oops"] = id(oops_button).state;
-              root["rfid_value"] = id(rfid_tag);
-              root["uptime"] = id(uptime_sensor).state;
-              root["wifi_signal_db"] = id(wifi_signal_db).state;
-              root["wifi_signal_percent"] = id(wifi_signal_percent).state;
-              root["internal_temperature_c"] = id(internal_temperature_c).state;
-              root["second_relay_state"] = id(relay2_output).state;
-            capture_response: true
-            on_response:
-              then:
-                - lambda: |-
-                    json::parse_json(body, [](JsonObject root) -> bool {
-                        if ( root["relay"]) {
-                          ESP_LOGI("RELAY", "Turn relay on");
-                          id(relay_output).turn_on();
-                        } else {
-                          ESP_LOGI("RELAY", "Turn relay off");
-                          id(relay_output).turn_off();
-                        }
-                        std::string dcontent = root["display"];
-                        id(display_content) = dcontent;
-                        id(my_display).print(dcontent);
-                        if ( root["oops_led"]) {
-                          ESP_LOGI("OOPS", "Turn oops LED on");
-                          id(oops_led).turn_on();
-                        } else {
-                          ESP_LOGI("OOPS", "Turn oops LED off");
-                          id(oops_led).turn_off();
-                        }
-                        auto call = id(status_led).turn_on();
-                        float brightness = root["status_led_brightness"];
-                        call.set_brightness(brightness);
-                        call.set_rgb(root["status_led_rgb"][0], root["status_led_rgb"][1], root["status_led_rgb"][2]);
-                        call.perform();
-                        bool sr_state = root["second_relay"] | false;
-                        if ( sr_state) {
-                          ESP_LOGI("RELAY2", "Turn second relay on");
-                          id(relay2_output).turn_on();
-                        } else {
-                          ESP_LOGI("RELAY2", "Turn second relay off");
-                          id(relay2_output).turn_off();
-                        }
-                        return true;
-                    });
+        - script.execute: post_to_mac
 
 button:
   - platform: restart
@@ -315,56 +272,7 @@ wiegand:
             id(rfid_tag) = x.c_str();
             id(display_content) = ((std::string) "TAG RX: " + x).c_str();
             id(my_display).print(((std::string) "TAG RX: " + x).c_str());
-      - http_request.post:
-          url: !secret mac_url
-          request_headers:
-            Content-Type: application/json
-          json: |-
-              root["machine_name"] = App.get_name().c_str();
-              root["oops"] = id(oops_button).state;
-              root["rfid_value"] = id(rfid_tag);
-              root["uptime"] = id(uptime_sensor).state;
-              root["wifi_signal_db"] = id(wifi_signal_db).state;
-              root["wifi_signal_percent"] = id(wifi_signal_percent).state;
-              root["internal_temperature_c"] = id(internal_temperature_c).state;
-              root["second_relay_state"] = id(relay2_output).state;
-          capture_response: true
-          on_response:
-            then:
-              - lambda: |-
-                  json::parse_json(body, [](JsonObject root) -> bool {
-                      if ( root["relay"]) {
-                        ESP_LOGI("RELAY", "Turn relay on");
-                        id(relay_output).turn_on();
-                      } else {
-                        ESP_LOGI("RELAY", "Turn relay off");
-                        id(relay_output).turn_off();
-                      }
-                      std::string dcontent = root["display"];
-                      id(display_content) = dcontent;
-                      id(my_display).print(dcontent);
-                      if ( root["oops_led"]) {
-                        ESP_LOGI("OOPS", "Turn oops LED on");
-                        id(oops_led).turn_on();
-                      } else {
-                        ESP_LOGI("OOPS", "Turn oops LED off");
-                        id(oops_led).turn_off();
-                      }
-                      auto call = id(status_led).turn_on();
-                      float brightness = root["status_led_brightness"];
-                      call.set_brightness(brightness);
-                      call.set_rgb(root["status_led_rgb"][0], root["status_led_rgb"][1], root["status_led_rgb"][2]);
-                      call.perform();
-                      bool sr_state = root["second_relay"] | false;
-                      if ( sr_state) {
-                        ESP_LOGI("RELAY2", "Turn second relay on");
-                        id(relay2_output).turn_on();
-                      } else {
-                        ESP_LOGI("RELAY2", "Turn second relay off");
-                        id(relay2_output).turn_off();
-                      }
-                      return true;
-                  });
+      - script.execute: post_to_mac
 
 display:
   - platform: lcd_pcf8574
@@ -375,56 +283,43 @@ display:
       it.print(id(display_content));
 
 interval:
+  # Heartbeat: post current state to mac_url every 10s.
   - interval: 10s
     startup_delay: 30s
     then:
-      - http_request.post:
-          url: !secret mac_url
-          request_headers:
-            Content-Type: application/json
-          json: |-
-            root["machine_name"] = App.get_name().c_str();
-            root["oops"] = id(oops_button).state;
-            root["rfid_value"] = id(rfid_tag);
-            root["uptime"] = id(uptime_sensor).state;
-            root["wifi_signal_db"] = id(wifi_signal_db).state;
-            root["wifi_signal_percent"] = id(wifi_signal_percent).state;
-            root["internal_temperature_c"] = id(internal_temperature_c).state;
-            root["second_relay_state"] = id(relay2_output).state;
-          capture_response: true
-          on_response:
-            then:
-              - lambda: |-
-                  json::parse_json(body, [](JsonObject root) -> bool {
-                      if ( root["relay"]) {
-                        ESP_LOGI("RELAY", "Turn relay on");
-                        id(relay_output).turn_on();
-                      } else {
-                        ESP_LOGI("RELAY", "Turn relay off");
-                        id(relay_output).turn_off();
-                      }
-                      std::string dcontent = root["display"];
-                      id(display_content) = dcontent;
-                      id(my_display).print(dcontent);
-                      if ( root["oops_led"]) {
-                        ESP_LOGI("OOPS", "Turn oops LED on");
-                        id(oops_led).turn_on();
-                      } else {
-                        ESP_LOGI("OOPS", "Turn oops LED off");
-                        id(oops_led).turn_off();
-                      }
-                      auto call = id(status_led).turn_on();
-                      float brightness = root["status_led_brightness"];
-                      call.set_brightness(brightness);
-                      call.set_rgb(root["status_led_rgb"][0], root["status_led_rgb"][1], root["status_led_rgb"][2]);
-                      call.perform();
-                      bool sr_state = root["second_relay"] | false;
-                      if ( sr_state) {
-                        ESP_LOGI("RELAY2", "Turn second relay on");
-                        id(relay2_output).turn_on();
-                      } else {
-                        ESP_LOGI("RELAY2", "Turn second relay off");
-                        id(relay2_output).turn_off();
-                      }
-                      return true;
-                  });
+      - script.execute: post_to_mac
+
+  # Application-level liveness watchdog. Reboots the ESP if heartbeats
+  # have stopped landing successfully — but only when no relay is
+  # energized, so an in-progress operation (e.g. a laser cut) is not
+  # interrupted. While the relay is on and the link is stale, surface
+  # the condition on the LCD instead of rebooting; the next watchdog
+  # tick after the relay drops will then reboot cleanly.
+  #
+  # 90 s threshold tolerates ~9 missed heartbeats and a typical
+  # mac-server cold-start. 120 s startup_delay keeps this from firing
+  # before the first successful POST has had a chance to land.
+  #
+  # The ESP-IDF task watchdog (CONFIG_ESP_TASK_WDT_PANIC=y above) is
+  # the catastrophic-hang fallback if the loop task itself is wedged
+  # so badly this interval never fires.
+  - interval: 30s
+    startup_delay: 120s
+    then:
+      - lambda: |-
+          uint32_t now = (uint32_t) id(uptime_sensor).state;
+          uint32_t last = id(last_ok_post_uptime);
+          uint32_t stale = (last == 0) ? now : (now - last);
+          bool relay_on = id(relay_output).state || id(relay2_output).state;
+          if (stale > 90 && !relay_on) {
+            ESP_LOGE("WDOG",
+                     "No successful POST in %us; relay off; rebooting",
+                     stale);
+            App.safe_reboot();
+          } else if (stale > 90 && relay_on) {
+            ESP_LOGW("WDOG",
+                     "No successful POST in %us; relay ON; deferring reboot",
+                     stale);
+            id(display_content) = "WARN: server\nlink stale";
+            id(my_display).print(id(display_content));
+          }

--- a/esphome-configs/2025.11.2/no-current-input.yaml
+++ b/esphome-configs/2025.11.2/no-current-input.yaml
@@ -126,7 +126,7 @@ script:
             then:
               - lambda: |-
                   if (status_code >= 200 && status_code < 300) {
-                    json::parse_json(body, [](JsonObject root) -> bool {
+                    bool parse_ok = json::parse_json(body, [](JsonObject root) -> bool {
                         if ( root["relay"]) {
                           ESP_LOGI("RELAY", "Turn relay on");
                           id(relay_output).turn_on();
@@ -159,8 +159,15 @@ script:
                         }
                         return true;
                     });
-                    id(last_ok_post_uptime) = (uint32_t) id(uptime_sensor).state;
-                    id(consecutive_post_failures) = 0;
+                    if (parse_ok) {
+                      id(last_ok_post_uptime) = (uint32_t) id(uptime_sensor).state;
+                      id(consecutive_post_failures) = 0;
+                    } else {
+                      id(consecutive_post_failures) += 1;
+                      ESP_LOGW("HTTP",
+                               "2xx but JSON parse failed; consec=%u",
+                               id(consecutive_post_failures));
+                    }
                   } else {
                     id(consecutive_post_failures) += 1;
                     ESP_LOGW("HTTP", "Non-2xx response %d; consec=%u",

--- a/src/dm_mac/models/api_schemas.py
+++ b/src/dm_mac/models/api_schemas.py
@@ -67,6 +67,22 @@ class ErrorResponse(BaseModel):
     error: str = Field(description="Error message describing what went wrong.")
 
 
+class StateSaveTimeoutResponse(BaseModel):
+    """503 response body for the oops and locked_out endpoints when
+    persisting machine state to disk exceeds ``STATE_SAVE_TIMEOUT_SEC``.
+
+    The in-memory state mutation (and any fire-and-forget Slack
+    notification) has already taken effect; only the pickle write
+    timed out. The next successful save will catch up.
+    """
+
+    error: str = Field(description="Error message; always 'state save timeout'.")
+    action_applied: bool = Field(
+        description="True; the requested state mutation took effect in "
+        "memory even though persistence to disk timed out."
+    )
+
+
 class ReloadUsersResponse(BaseModel):
     """Response body for POST /api/reload-users (200)."""
 

--- a/src/dm_mac/models/machine.py
+++ b/src/dm_mac/models/machine.py
@@ -1,5 +1,6 @@
 """Model representing a machine."""
 
+import asyncio
 import logging
 import os
 import pickle
@@ -31,6 +32,21 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 logger: Logger = getLogger(__name__)
+
+
+#: Maximum wall-clock seconds we will spend persisting machine state to disk
+#: before raising :class:`StateSaveTimeoutError`. Keeps a single hung disk
+#: write from blocking the request handler long enough to wedge the firmware
+#: (see ``docs/2026-05-05-mcu-lockup-analysis.md``).
+STATE_SAVE_TIMEOUT_SEC: float = 2.0
+
+
+class StateSaveTimeoutError(Exception):
+    """Raised when persisting machine state to disk exceeds the budget.
+
+    Surfaced to MCU clients as HTTP 503 by the ``/machine/update`` view so
+    the firmware sees a clean error and recovers on its next heartbeat.
+    """
 
 
 _SECOND_RELAY_SCHEMA: Dict[str, Any] = {
@@ -342,6 +358,10 @@ class MachineState:
         #: Authorization decision outcome for the second relay
         #: (granted/denied/warn/always_enabled), or None if no second relay.
         self.second_relay_authorization: Optional[str] = None
+        #: Lifetime count of state-save timeouts for this machine. Persisted
+        #: with the rest of the machine state; surfaced as the
+        #: ``mac_state_save_timeouts_total`` Prometheus counter.
+        self.state_save_timeouts: int = 0
         #: Path to the directory to save machine state in
         self._state_dir: str = os.environ.get("MACHINE_STATE_DIR", "machine_state")
         os.makedirs(self._state_dir, exist_ok=True)
@@ -355,7 +375,13 @@ class MachineState:
             logger.warning("State loading disabled for machine %s", self.machine.name)
 
     def _save_cache(self) -> None:
-        """Save machine state cache to disk."""
+        """Save machine state cache to disk (synchronous).
+
+        Acquires the in-process lock and on-disk filelock, builds the state
+        dict, and writes the pickle. Used directly by maintenance tools and
+        tests; request handlers should call :meth:`save_cache` instead so
+        the write is bounded by :data:`STATE_SAVE_TIMEOUT_SEC`.
+        """
         logger.debug("Getting lock for state file: %s", self._state_path + ".lock")
         with self._lock:
             lock = FileLock(self._state_path + ".lock")
@@ -381,11 +407,71 @@ class MachineState:
                     "current_user": self.current_user,
                     "second_relay_desired_state": self.second_relay_desired_state,
                     "second_relay_authorization": self.second_relay_authorization,
+                    "state_save_timeouts": self.state_save_timeouts,
                 }
                 logger.debug("Saving state to: %s", self._state_path)
                 with open(self._state_path, "wb") as f:
                     pickle.dump(data, f, pickle.HIGHEST_PROTOCOL)
         logger.debug("State saved.")
+
+    async def save_cache(self) -> None:
+        """Save machine state cache to disk with a timeout.
+
+        Runs :meth:`_save_cache` in a worker thread and waits up to
+        :data:`STATE_SAVE_TIMEOUT_SEC` seconds for it to complete. On
+        timeout, increments :attr:`state_save_timeouts`, fires a Slack
+        notification when the count crosses 1, and raises
+        :class:`StateSaveTimeoutError`.
+        """
+        try:
+            await asyncio.wait_for(
+                asyncio.to_thread(self._save_cache),
+                timeout=STATE_SAVE_TIMEOUT_SEC,
+            )
+        except asyncio.TimeoutError as exc:
+            self.state_save_timeouts += 1
+            count = self.state_save_timeouts
+            logger.error(
+                "State save for machine %s exceeded %.1fs budget "
+                "(lifetime timeout count: %d)",
+                self.machine.name,
+                STATE_SAVE_TIMEOUT_SEC,
+                count,
+            )
+            self._notify_save_timeout(count)
+            raise StateSaveTimeoutError(
+                f"State save for {self.machine.name} exceeded "
+                f"{STATE_SAVE_TIMEOUT_SEC:.1f}s budget"
+            ) from exc
+
+    def _notify_save_timeout(self, count: int) -> None:
+        """Fire a fire-and-forget Slack notification on repeated save timeouts.
+
+        Skipped on the first timeout to tolerate single transient stalls;
+        every timeout where the lifetime count is >= 2 produces one
+        notification to ``SLACK_CONTROL_CHANNEL_ID``.
+        """
+        if count < 2:
+            return
+        slack: Optional["SlackHandler"] = current_app.config.get("SLACK_HANDLER")
+        if slack is None:
+            return
+        msg = (
+            f":warning: Machine `{self.machine.display_name}` had a state-save "
+            f"timeout (>{STATE_SAVE_TIMEOUT_SEC:.1f}s); lifetime count is now "
+            f"{count}. Disk may be hung; firmware was returned HTTP 503."
+        )
+        try:
+            asyncio.create_task(
+                slack.app.client.chat_postMessage(
+                    channel=slack.control_channel_id,
+                    text=msg,
+                )
+            )
+        except RuntimeError:  # pragma: no cover - no running loop
+            logger.debug(
+                "No running event loop; skipping Slack save-timeout notification"
+            )
 
     def _load_from_cache(self) -> None:
         """Load machine state cache from disk."""
@@ -596,7 +682,7 @@ class MachineState:
                     self.status_led_brightness = 0.0
                     self.last_update = time()
             self._resolve_second_relay()
-        self._save_cache()
+        await self.save_cache()
         return self.machine_response
 
     async def _handle_oops(self, users: UsersConfig) -> None:

--- a/src/dm_mac/models/machine.py
+++ b/src/dm_mac/models/machine.py
@@ -44,8 +44,10 @@ STATE_SAVE_TIMEOUT_SEC: float = 2.0
 class StateSaveTimeoutError(Exception):
     """Raised when persisting machine state to disk exceeds the budget.
 
-    Surfaced to MCU clients as HTTP 503 by the ``/machine/update`` view so
-    the firmware sees a clean error and recovers on its next heartbeat.
+    Surfaced to MCU clients as HTTP 503 by the ``/api/machine/update``
+    view (and by ``/api/machine/oops/<name>`` and
+    ``/api/machine/locked_out/<name>``) so the firmware sees a clean
+    error and recovers on its next heartbeat.
     """
 
 
@@ -359,9 +361,20 @@ class MachineState:
         #: (granted/denied/warn/always_enabled), or None if no second relay.
         self.second_relay_authorization: Optional[str] = None
         #: Lifetime count of state-save timeouts for this machine. Persisted
-        #: with the rest of the machine state; surfaced as the
-        #: ``mac_state_save_timeouts_total`` Prometheus counter.
+        #: with the rest of the machine state (best-effort: a write that
+        #: itself times out cannot persist the increment until the next
+        #: successful save); surfaced as the
+        #: ``mac_state_save_timeouts_total`` Prometheus counter from the
+        #: in-memory value, which is always increment-correct because
+        #: :meth:`save_cache` is single-flight per machine.
         self.state_save_timeouts: int = 0
+        #: Tracks the in-flight ``asyncio.to_thread`` task spawned by
+        #: :meth:`save_cache`. While this task is running (or hung on a
+        #: stuck disk) subsequent calls to :meth:`save_cache` fail-fast
+        #: with :class:`StateSaveTimeoutError` instead of spawning more
+        #: threads, so a single hung disk write cannot exhaust the
+        #: default thread pool.
+        self._save_task: Optional["asyncio.Task[None]"] = None
         #: Path to the directory to save machine state in
         self._state_dir: str = os.environ.get("MACHINE_STATE_DIR", "machine_state")
         os.makedirs(self._state_dir, exist_ok=True)
@@ -417,32 +430,63 @@ class MachineState:
     async def save_cache(self) -> None:
         """Save machine state cache to disk with a timeout.
 
-        Runs :meth:`_save_cache` in a worker thread and waits up to
-        :data:`STATE_SAVE_TIMEOUT_SEC` seconds for it to complete. On
-        timeout, increments :attr:`state_save_timeouts`, fires a Slack
-        notification when the count crosses 1, and raises
-        :class:`StateSaveTimeoutError`.
+        Single-flight per machine: only one save thread can be
+        outstanding at a time. If a previous save is still running
+        (typically because the disk is hung) a new call returns
+        immediately with :class:`StateSaveTimeoutError` instead of
+        spawning another thread that would also block on the same
+        disk; this prevents thread-pool exhaustion under a sustained
+        disk hang while heartbeats keep arriving.
+
+        Otherwise spawns a worker thread to run :meth:`_save_cache`
+        and waits up to :data:`STATE_SAVE_TIMEOUT_SEC` seconds for it
+        to complete. On timeout, the underlying thread is *shielded*
+        and continues running (Python cannot cancel a thread blocked
+        on file I/O); :attr:`state_save_timeouts` is incremented and a
+        Slack notification fires once the lifetime count is >= 2.
         """
+        in_flight = self._save_task
+        if in_flight is not None and not in_flight.done():
+            count = self._record_save_timeout(reason="save already in flight")
+            raise StateSaveTimeoutError(
+                f"State save for {self.machine.name} already in flight "
+                f"(lifetime timeout count: {count})"
+            )
+
+        # Spawn the worker as a Task so we can both `shield` it (so that
+        # wait_for cancelling does not propagate to the underlying thread,
+        # which cannot be cancelled anyway) and check `.done()` on
+        # subsequent calls.
+        task: "asyncio.Task[None]" = asyncio.create_task(
+            asyncio.to_thread(self._save_cache)
+        )
+        self._save_task = task
         try:
-            await asyncio.wait_for(
-                asyncio.to_thread(self._save_cache),
-                timeout=STATE_SAVE_TIMEOUT_SEC,
-            )
+            await asyncio.wait_for(asyncio.shield(task), timeout=STATE_SAVE_TIMEOUT_SEC)
         except asyncio.TimeoutError as exc:
-            self.state_save_timeouts += 1
-            count = self.state_save_timeouts
-            logger.error(
-                "State save for machine %s exceeded %.1fs budget "
-                "(lifetime timeout count: %d)",
-                self.machine.name,
-                STATE_SAVE_TIMEOUT_SEC,
-                count,
-            )
-            self._notify_save_timeout(count)
+            count = self._record_save_timeout(reason="exceeded budget")
             raise StateSaveTimeoutError(
                 f"State save for {self.machine.name} exceeded "
-                f"{STATE_SAVE_TIMEOUT_SEC:.1f}s budget"
+                f"{STATE_SAVE_TIMEOUT_SEC:.1f}s budget "
+                f"(lifetime timeout count: {count})"
             ) from exc
+
+    def _record_save_timeout(self, reason: str) -> int:
+        """Increment the timeout counter, log, and notify Slack.
+
+        Returns the post-increment lifetime count so callers can
+        include it in the raised exception.
+        """
+        self.state_save_timeouts += 1
+        count = self.state_save_timeouts
+        logger.error(
+            "State save for machine %s timed out (%s); " "lifetime timeout count: %d",
+            self.machine.name,
+            reason,
+            count,
+        )
+        self._notify_save_timeout(count)
+        return count
 
     def _notify_save_timeout(self, count: int) -> None:
         """Fire a fire-and-forget Slack notification on repeated save timeouts.

--- a/src/dm_mac/models/machine.py
+++ b/src/dm_mac/models/machine.py
@@ -460,6 +460,12 @@ class MachineState:
         task: "asyncio.Task[None]" = asyncio.create_task(
             asyncio.to_thread(self._save_cache)
         )
+        # If the underlying thread eventually completes after we've timed
+        # out, consume any exception it produced so the event loop doesn't
+        # log "Task exception was never retrieved". Also clear our
+        # reference so subsequent save_cache calls aren't blocked forever
+        # waiting on a task we've already given up on.
+        task.add_done_callback(self._on_save_task_done)
         self._save_task = task
         try:
             await asyncio.wait_for(asyncio.shield(task), timeout=STATE_SAVE_TIMEOUT_SEC)
@@ -470,6 +476,29 @@ class MachineState:
                 f"{STATE_SAVE_TIMEOUT_SEC:.1f}s budget "
                 f"(lifetime timeout count: {count})"
             ) from exc
+
+    def _on_save_task_done(self, task: "asyncio.Task[None]") -> None:
+        """Done-callback for the in-flight save task.
+
+        Logs (and thus consumes) any exception the underlying
+        :meth:`_save_cache` raised, so a thread that finishes after we
+        have already timed out cannot leak unhandled exceptions into
+        the event loop. Also clears :attr:`_save_task` if this is still
+        the current task, so a subsequent successful save can run.
+        """
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            exc = None
+        if exc is not None:
+            logger.warning(
+                "Background state save for machine %s finished with "
+                "an exception: %r",
+                self.machine.name,
+                exc,
+            )
+        if self._save_task is task:
+            self._save_task = None
 
     def _record_save_timeout(self, reason: str) -> int:
         """Increment the timeout counter, log, and notify Slack.
@@ -489,13 +518,16 @@ class MachineState:
         return count
 
     def _notify_save_timeout(self, count: int) -> None:
-        """Fire a fire-and-forget Slack notification on repeated save timeouts.
+        """Fire a fire-and-forget Slack notification on the 2nd save timeout.
 
         Skipped on the first timeout to tolerate single transient stalls;
-        every timeout where the lifetime count is >= 2 produces one
-        notification to ``SLACK_CONTROL_CHANNEL_ID``.
+        fired *exactly once* on the transition to 2 to avoid spamming
+        ``SLACK_CONTROL_CHANNEL_ID`` under a sustained disk hang (where
+        timeouts can arrive every ~10 s as MCU heartbeats keep coming).
+        Operators monitoring the ``mac_state_save_timeouts_total``
+        Prometheus counter can alert on sustained increase from there.
         """
-        if count < 2:
+        if count != 2:
             return
         slack: Optional["SlackHandler"] = current_app.config.get("SLACK_HANDLER")
         if slack is None:

--- a/src/dm_mac/models/machine.py
+++ b/src/dm_mac/models/machine.py
@@ -370,11 +370,22 @@ class MachineState:
         self.state_save_timeouts: int = 0
         #: Tracks the in-flight ``asyncio.to_thread`` task spawned by
         #: :meth:`save_cache`. While this task is running (or hung on a
-        #: stuck disk) subsequent calls to :meth:`save_cache` fail-fast
-        #: with :class:`StateSaveTimeoutError` instead of spawning more
-        #: threads, so a single hung disk write cannot exhaust the
-        #: default thread pool.
+        #: stuck disk) subsequent calls to :meth:`save_cache` *join*
+        #: the existing task instead of spawning more threads, so a
+        #: single hung disk write cannot exhaust the default thread
+        #: pool. Each joiner gets its own :data:`STATE_SAVE_TIMEOUT_SEC`
+        #: budget, so brief overlap finishes successfully while a
+        #: sustained hang produces independent timeout events on each
+        #: subsequent request (which is what drives the
+        #: :func:`mac_state_save_timeouts_total <prometheus>` counter
+        #: and the Slack-on-second-timeout rule).
         self._save_task: Optional["asyncio.Task[None]"] = None
+        #: Guards the check-and-set of :attr:`_save_task` so two
+        #: concurrent callers cannot both observe ``_save_task`` as
+        #: ``None``/``done()`` and spawn separate workers. Lazily
+        #: created on first use so we don't bind to a specific event
+        #: loop at construction time.
+        self._save_spawn_lock: Optional[asyncio.Lock] = None
         #: Path to the directory to save machine state in
         self._state_dir: str = os.environ.get("MACHINE_STATE_DIR", "machine_state")
         os.makedirs(self._state_dir, exist_ok=True)
@@ -430,43 +441,49 @@ class MachineState:
     async def save_cache(self) -> None:
         """Save machine state cache to disk with a timeout.
 
-        Single-flight per machine: only one save thread can be
-        outstanding at a time. If a previous save is still running
-        (typically because the disk is hung) a new call returns
-        immediately with :class:`StateSaveTimeoutError` instead of
-        spawning another thread that would also block on the same
-        disk; this prevents thread-pool exhaustion under a sustained
-        disk hang while heartbeats keep arriving.
+        Single-flight per machine: only one save *thread* is
+        outstanding at a time. Concurrent callers see the existing
+        in-flight task and *join* it (awaiting the same task) rather
+        than spawning a second thread that would also block on the
+        same disk lock; this prevents thread-pool exhaustion under a
+        sustained disk hang while heartbeats keep arriving.
 
-        Otherwise spawns a worker thread to run :meth:`_save_cache`
-        and waits up to :data:`STATE_SAVE_TIMEOUT_SEC` seconds for it
-        to complete. On timeout, the underlying thread is *shielded*
-        and continues running (Python cannot cancel a thread blocked
-        on file I/O); :attr:`state_save_timeouts` is incremented and a
-        Slack notification fires once the lifetime count is >= 2.
+        Whether the caller spawned the task or joined an existing
+        one, it then awaits with its own :data:`STATE_SAVE_TIMEOUT_SEC`
+        budget. Brief overlap (the existing save finishes within the
+        joiner's budget) returns success without counting a timeout.
+        A sustained hang produces an independent timeout event on
+        each request that exceeds its budget; the second such event
+        triggers the Slack notification.
+
+        On timeout, the underlying thread is *shielded* and continues
+        running (Python cannot cancel a thread blocked on file I/O);
+        :attr:`state_save_timeouts` is incremented and
+        :class:`StateSaveTimeoutError` is raised.
         """
-        in_flight = self._save_task
-        if in_flight is not None and not in_flight.done():
-            count = self._record_save_timeout(reason="save already in flight")
-            raise StateSaveTimeoutError(
-                f"State save for {self.machine.name} already in flight "
-                f"(lifetime timeout count: {count})"
-            )
+        if self._save_spawn_lock is None:
+            self._save_spawn_lock = asyncio.Lock()
+        async with self._save_spawn_lock:
+            existing = self._save_task
+            if existing is not None and not existing.done():
+                # Join the in-flight save: brief overlap finishes
+                # quickly without spawning a second thread, while a
+                # sustained hang lets us hit our own budget below.
+                task = existing
+            else:
+                # Spawn the worker as a Task so we can both `shield`
+                # it (so that wait_for cancelling does not propagate
+                # to the underlying thread, which cannot be cancelled
+                # anyway) and check `.done()` on subsequent calls.
+                task = asyncio.create_task(asyncio.to_thread(self._save_cache))
+                # If the underlying thread eventually completes after
+                # we've timed out, consume any exception it produced
+                # so the event loop doesn't log "Task exception was
+                # never retrieved". Also clear our reference so
+                # subsequent save_cache calls can spawn a new worker.
+                task.add_done_callback(self._on_save_task_done)
+                self._save_task = task
 
-        # Spawn the worker as a Task so we can both `shield` it (so that
-        # wait_for cancelling does not propagate to the underlying thread,
-        # which cannot be cancelled anyway) and check `.done()` on
-        # subsequent calls.
-        task: "asyncio.Task[None]" = asyncio.create_task(
-            asyncio.to_thread(self._save_cache)
-        )
-        # If the underlying thread eventually completes after we've timed
-        # out, consume any exception it produced so the event loop doesn't
-        # log "Task exception was never retrieved". Also clear our
-        # reference so subsequent save_cache calls aren't blocked forever
-        # waiting on a task we've already given up on.
-        task.add_done_callback(self._on_save_task_done)
-        self._save_task = task
         try:
             await asyncio.wait_for(asyncio.shield(task), timeout=STATE_SAVE_TIMEOUT_SEC)
         except asyncio.TimeoutError as exc:

--- a/src/dm_mac/views/machine.py
+++ b/src/dm_mac/views/machine.py
@@ -23,6 +23,7 @@ from dm_mac.models.api_schemas import MachineUpdateResponse
 from dm_mac.models.api_schemas import SuccessResponse
 from dm_mac.models.machine import Machine
 from dm_mac.models.machine import MachinesConfig
+from dm_mac.models.machine import StateSaveTimeoutError
 from dm_mac.models.users import UsersConfig
 
 
@@ -37,6 +38,7 @@ machineapi: Blueprint = Blueprint("machine", __name__, url_prefix="/machine")
 @document_response(MachineUpdateResponse, 200)
 @document_response(ErrorResponse, 404)
 @document_response(ErrorResponse, 500)
+@document_response(ErrorResponse, 503)
 async def update() -> Tuple[Response, int]:
     """API method to update machine state.
 
@@ -114,6 +116,13 @@ async def update() -> Tuple[Response, int]:
     try:
         resp = await machine.update(users, **data)
         return jsonify(resp), 200
+    except StateSaveTimeoutError as ex:
+        logger.error(
+            "State save timeout for machine %s; returning 503 to firmware: %s",
+            machine_name,
+            ex,
+        )
+        return jsonify({"error": "state save timeout"}), 503
     except Exception as ex:
         logger.error("Error in machine update %s: %s", data, ex, exc_info=True)
         return jsonify({"error": str(ex)}), 500
@@ -124,6 +133,7 @@ async def update() -> Tuple[Response, int]:
 @document_response(SuccessResponse, 200)
 @document_response(ErrorResponse, 404)
 @document_response(ErrorResponse, 500)
+@document_response(ErrorResponse, 503)
 async def oops(machine_name: str) -> Tuple[Response, int]:
     """Set or clear machine Oops state.
 
@@ -141,8 +151,16 @@ async def oops(machine_name: str) -> Tuple[Response, int]:
             await machine.unoops()
         else:
             await machine.oops()
-        machine.state._save_cache()
+        await machine.state.save_cache()
         return jsonify({"success": True}), 200
+    except StateSaveTimeoutError as ex:
+        logger.error(
+            "State save timeout in %s oops for machine %s: %s",
+            method,
+            machine_name,
+            ex,
+        )
+        return jsonify({"error": "state save timeout"}), 503
     except Exception as ex:
         logger.error(
             "Error in %s oops for machine %s: %s",
@@ -159,6 +177,7 @@ async def oops(machine_name: str) -> Tuple[Response, int]:
 @document_response(SuccessResponse, 200)
 @document_response(ErrorResponse, 404)
 @document_response(ErrorResponse, 500)
+@document_response(ErrorResponse, 503)
 async def locked_out(machine_name: str) -> Tuple[Response, int]:
     """Set or clear machine lockout state.
 
@@ -176,8 +195,16 @@ async def locked_out(machine_name: str) -> Tuple[Response, int]:
             await machine.unlock()
         else:
             await machine.lockout()
-        machine.state._save_cache()
+        await machine.state.save_cache()
         return jsonify({"success": True}), 200
+    except StateSaveTimeoutError as ex:
+        logger.error(
+            "State save timeout in %s locked_out for machine %s: %s",
+            method,
+            machine_name,
+            ex,
+        )
+        return jsonify({"error": "state save timeout"}), 503
     except Exception as ex:
         logger.error(
             "Error in %s locked_out for machine %s: %s",

--- a/src/dm_mac/views/machine.py
+++ b/src/dm_mac/views/machine.py
@@ -154,13 +154,27 @@ async def oops(machine_name: str) -> Tuple[Response, int]:
         await machine.state.save_cache()
         return jsonify({"success": True}), 200
     except StateSaveTimeoutError as ex:
+        # The in-memory state mutation and any Slack notification have
+        # already taken effect; only persistence to disk failed. Surface
+        # 503 so monitoring catches the disk problem, but include
+        # `action_applied: true` so the API caller knows the requested
+        # change is live and the next successful save will catch up.
         logger.error(
-            "State save timeout in %s oops for machine %s: %s",
+            "State save timeout in %s oops for machine %s "
+            "(action applied in memory; persistence deferred): %s",
             method,
             machine_name,
             ex,
         )
-        return jsonify({"error": "state save timeout"}), 503
+        return (
+            jsonify(
+                {
+                    "error": "state save timeout",
+                    "action_applied": True,
+                }
+            ),
+            503,
+        )
     except Exception as ex:
         logger.error(
             "Error in %s oops for machine %s: %s",
@@ -198,13 +212,26 @@ async def locked_out(machine_name: str) -> Tuple[Response, int]:
         await machine.state.save_cache()
         return jsonify({"success": True}), 200
     except StateSaveTimeoutError as ex:
+        # See oops() above: the in-memory lockout transition has already
+        # taken effect; only the pickle write timed out. Signal both via
+        # 503 (so monitoring fires) and `action_applied: true` (so the
+        # API caller knows the lock/unlock is live).
         logger.error(
-            "State save timeout in %s locked_out for machine %s: %s",
+            "State save timeout in %s locked_out for machine %s "
+            "(action applied in memory; persistence deferred): %s",
             method,
             machine_name,
             ex,
         )
-        return jsonify({"error": "state save timeout"}), 503
+        return (
+            jsonify(
+                {
+                    "error": "state save timeout",
+                    "action_applied": True,
+                }
+            ),
+            503,
+        )
     except Exception as ex:
         logger.error(
             "Error in %s locked_out for machine %s: %s",

--- a/src/dm_mac/views/machine.py
+++ b/src/dm_mac/views/machine.py
@@ -20,6 +20,7 @@ from quart_schema import tag
 from dm_mac.models.api_schemas import ErrorResponse
 from dm_mac.models.api_schemas import MachineUpdateRequest
 from dm_mac.models.api_schemas import MachineUpdateResponse
+from dm_mac.models.api_schemas import StateSaveTimeoutResponse
 from dm_mac.models.api_schemas import SuccessResponse
 from dm_mac.models.machine import Machine
 from dm_mac.models.machine import MachinesConfig
@@ -133,7 +134,7 @@ async def update() -> Tuple[Response, int]:
 @document_response(SuccessResponse, 200)
 @document_response(ErrorResponse, 404)
 @document_response(ErrorResponse, 500)
-@document_response(ErrorResponse, 503)
+@document_response(StateSaveTimeoutResponse, 503)
 async def oops(machine_name: str) -> Tuple[Response, int]:
     """Set or clear machine Oops state.
 
@@ -191,7 +192,7 @@ async def oops(machine_name: str) -> Tuple[Response, int]:
 @document_response(SuccessResponse, 200)
 @document_response(ErrorResponse, 404)
 @document_response(ErrorResponse, 500)
-@document_response(ErrorResponse, 503)
+@document_response(StateSaveTimeoutResponse, 503)
 async def locked_out(machine_name: str) -> Tuple[Response, int]:
     """Set or clear machine lockout state.
 

--- a/src/dm_mac/views/prometheus.py
+++ b/src/dm_mac/views/prometheus.py
@@ -13,6 +13,7 @@ from prometheus_client.samples import Sample
 from quart import Response
 from quart import current_app
 
+from dm_mac.models.machine import STATE_SAVE_TIMEOUT_SEC
 from dm_mac.models.machine import Machine
 from dm_mac.models.machine import MachinesConfig
 from dm_mac.models.users import UsersConfig
@@ -52,10 +53,33 @@ class LabeledGaugeMetricFamily(Metric):
         self.samples.append(Sample(self.name, dict(labels | self._labels), value, None))
 
 
+class LabeledCounterMetricFamily(Metric):
+    """Counter metric with labels, sibling to LabeledGaugeMetricFamily."""
+
+    def __init__(
+        self,
+        name: str,
+        documentation: str,
+        labels: Optional[Dict[str, str]] = None,
+        unit: str = "",
+    ):
+        """Initialize LabeledCounterMetricFamily."""
+        Metric.__init__(self, name, documentation, "counter", unit)
+        if labels is None:
+            labels = {}
+        self._labels = labels
+
+    def add_metric(self, labels: Dict[str, str], value: float) -> None:
+        """Add a counter sample under ``<name>_total``."""
+        self.samples.append(
+            Sample(self.name + "_total", dict(labels | self._labels), value, None)
+        )
+
+
 class PromCustomCollector:
     """Custom collector for metrics."""
 
-    def collect(self) -> Generator[LabeledGaugeMetricFamily, None, None]:
+    def collect(self) -> Generator[Metric, None, None]:
         """Collect custom metrics."""
         mconf: MachinesConfig = current_app.config["MACHINES"]  # noqa
         uconf: UsersConfig = current_app.config["USERS"]  # noqa
@@ -161,6 +185,11 @@ class PromCustomCollector:
             "The always_enabled flag on the machine's second_relay "
             "(only emitted for machines with second_relay configured)",
         )
+        save_timeouts: LabeledCounterMetricFamily = LabeledCounterMetricFamily(
+            "mac_state_save_timeouts",
+            f"Lifetime count of state-save timeouts (>{STATE_SAVE_TIMEOUT_SEC:.1f}s) "
+            f"for the machine",
+        )
         m: Machine
         for m in mconf.machines:
             labels = {"machine_name": m.name, "display_name": m.display_name}
@@ -197,6 +226,7 @@ class PromCustomCollector:
                 {**labels, "led_attribute": "brightness"},
                 m.state.status_led_brightness,
             )
+            save_timeouts.add_metric(labels, m.state.state_save_timeouts)
             if m.second_relay is not None:
                 sr_labels = {
                     **labels,
@@ -234,6 +264,7 @@ class PromCustomCollector:
         yield wifi_percent
         yield temp_c
         yield led
+        yield save_timeouts
         # Only yield the second-relay metrics when at least one machine has
         # a second_relay configured. This keeps single-relay deployments
         # byte-identical to the pre-feature output.

--- a/tests/models/test_machine_state.py
+++ b/tests/models/test_machine_state.py
@@ -13,7 +13,6 @@ from unittest.mock import patch
 
 import pytest
 
-from dm_mac.models.machine import STATE_SAVE_TIMEOUT_SEC
 from dm_mac.models.machine import Machine
 from dm_mac.models.machine import MachineState
 from dm_mac.models.machine import StateSaveTimeoutError
@@ -548,8 +547,11 @@ class TestAsyncSaveCache(MachineStateTester):
     async def test_timeout_raises_and_increments_counter(self) -> None:
         """A slow underlying save raises StateSaveTimeoutError and counts."""
 
+        # Sleep just long enough to outlast the patched 0.1s budget; using
+        # the unpatched STATE_SAVE_TIMEOUT_SEC (2.0s) here would make the
+        # test sleep for 2.5s for no reason.
         def slow_save() -> None:
-            time.sleep(STATE_SAVE_TIMEOUT_SEC + 0.5)
+            time.sleep(0.3)
 
         with patch.object(self.cls, "_save_cache", side_effect=slow_save):
             with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.1):

--- a/tests/models/test_machine_state.py
+++ b/tests/models/test_machine_state.py
@@ -1,14 +1,22 @@
 """Tests for models.machine."""
 
+import asyncio
 import os
 import pickle
+import time
 from pathlib import Path
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import call
 from unittest.mock import patch
 
+import pytest
+
+from dm_mac.models.machine import STATE_SAVE_TIMEOUT_SEC
 from dm_mac.models.machine import Machine
 from dm_mac.models.machine import MachineState
+from dm_mac.models.machine import StateSaveTimeoutError
 from dm_mac.models.users import User
 from dm_mac.models.users import UsersConfig
 
@@ -155,6 +163,7 @@ class TestSaveCache(MachineStateTester):
             "current_user": None,
             "second_relay_desired_state": False,
             "second_relay_authorization": None,
+            "state_save_timeouts": 0,
         }
 
     def test_non_defaults(self, tmp_path: Path, fixtures_path: str) -> None:
@@ -207,6 +216,7 @@ class TestSaveCache(MachineStateTester):
             "current_user": user,
             "second_relay_desired_state": False,
             "second_relay_authorization": None,
+            "state_save_timeouts": 0,
         }
 
 
@@ -518,3 +528,97 @@ class TestOverrideLogin(MachineStateTester):
         assert self.cls.is_override_login is True
         assert self.cls.is_oopsed is True
         assert self.cls.relay_desired_state is True
+
+
+class TestAsyncSaveCache(MachineStateTester):
+    """Tests for the timeout-bounded async ``save_cache`` wrapper."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_writes_pickle(self, tmp_path: Path) -> None:
+        """Async wrapper completes well under the budget on a normal disk."""
+        self.cls._state_path = str(tmp_path) + "/MachineName-state.pickle"
+        await self.cls.save_cache()
+        assert self.cls.state_save_timeouts == 0
+        with open(os.path.join(tmp_path, "MachineName-state.pickle"), "rb") as f:
+            state = pickle.load(f)
+        assert state["machine_name"] == "MachineName"
+        assert state["state_save_timeouts"] == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_and_increments_counter(self) -> None:
+        """A slow underlying save raises StateSaveTimeoutError and counts."""
+
+        def slow_save() -> None:
+            time.sleep(STATE_SAVE_TIMEOUT_SEC + 0.5)
+
+        with patch.object(self.cls, "_save_cache", side_effect=slow_save):
+            with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.1):
+                with pytest.raises(StateSaveTimeoutError):
+                    await self.cls.save_cache()
+        assert self.cls.state_save_timeouts == 1
+
+    @pytest.mark.asyncio
+    async def test_first_timeout_does_not_notify_slack(self) -> None:
+        """A single transient timeout must not page Slack."""
+
+        def slow_save() -> None:
+            time.sleep(0.5)
+
+        slack = MagicMock()
+        slack.app.client.chat_postMessage = AsyncMock()
+        slack.control_channel_id = "C123"
+        m_app = MagicMock()
+        m_app.config = {"SLACK_HANDLER": slack}
+        with patch(f"{pbm}.current_app", new=m_app):
+            with patch.object(self.cls, "_save_cache", side_effect=slow_save):
+                with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.05):
+                    with pytest.raises(StateSaveTimeoutError):
+                        await self.cls.save_cache()
+        assert self.cls.state_save_timeouts == 1
+        slack.app.client.chat_postMessage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_second_timeout_notifies_slack(self) -> None:
+        """The second-or-later timeout must fire a Slack notification."""
+
+        def slow_save() -> None:
+            time.sleep(0.5)
+
+        slack = MagicMock()
+        slack.app.client.chat_postMessage = AsyncMock()
+        slack.control_channel_id = "C123"
+        type(self.machine).display_name = "MachineDisplayName"
+        # Pre-seed one prior timeout
+        self.cls.state_save_timeouts = 1
+        m_app = MagicMock()
+        m_app.config = {"SLACK_HANDLER": slack}
+        with patch(f"{pbm}.current_app", new=m_app):
+            with patch.object(self.cls, "_save_cache", side_effect=slow_save):
+                with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.05):
+                    with pytest.raises(StateSaveTimeoutError):
+                        await self.cls.save_cache()
+                    # Allow the create_task() to be scheduled before assertion
+                    await asyncio.sleep(0)
+        assert self.cls.state_save_timeouts == 2
+        slack.app.client.chat_postMessage.assert_called_once()
+        kwargs = slack.app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["channel"] == "C123"
+        assert "MachineDisplayName" in kwargs["text"]
+        assert "2" in kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_slack_handler_does_not_error(self) -> None:
+        """When SLACK_HANDLER is absent the notify path is silently skipped."""
+
+        def slow_save() -> None:
+            time.sleep(0.5)
+
+        self.cls.state_save_timeouts = 5
+        m_app = MagicMock()
+        m_app.config = {}
+        with patch(f"{pbm}.current_app", new=m_app):
+            with patch.object(self.cls, "_save_cache", side_effect=slow_save):
+                with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.05):
+                    with pytest.raises(StateSaveTimeoutError):
+                        await self.cls.save_cache()
+        assert self.cls.state_save_timeouts == 6

--- a/tests/models/test_machine_state.py
+++ b/tests/models/test_machine_state.py
@@ -609,9 +609,14 @@ class TestAsyncSaveCache(MachineStateTester):
         assert "2" in kwargs["text"]
 
     @pytest.mark.asyncio
-    async def test_single_flight_fails_fast_when_save_in_progress(self) -> None:
-        """A second call while the first is still running fails immediately
-        instead of spawning another thread (preventing pool exhaustion)."""
+    async def test_single_flight_joins_existing_task_under_sustained_hang(
+        self,
+    ) -> None:
+        """A second call while the first is still running joins the same
+        task instead of spawning another thread (preventing pool exhaustion).
+        Each caller hits its own budget and counts as a timeout, so a
+        sustained hang correctly drives the counter to >= 2 (which is what
+        triggers the Slack notification)."""
 
         # Use a real Event so the underlying thread blocks deterministically
         # and we can assert that no second thread was spawned.
@@ -629,10 +634,12 @@ class TestAsyncSaveCache(MachineStateTester):
         with patch(f"{pbm}.current_app", new=m_app):
             with patch.object(self.cls, "_save_cache", side_effect=slow_save):
                 with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.05):
-                    # First call hits the budget timeout while the thread blocks
+                    # First call spawns the task, hits the budget while
+                    # the thread is still blocked.
                     with pytest.raises(StateSaveTimeoutError) as exc1:
                         await self.cls.save_cache()
-                    # Second call sees the still-running task and fails-fast
+                    # Second call joins the same in-flight task and
+                    # also hits its own budget (the disk is still hung).
                     with pytest.raises(StateSaveTimeoutError) as exc2:
                         await self.cls.save_cache()
 
@@ -640,8 +647,48 @@ class TestAsyncSaveCache(MachineStateTester):
         block_thread.set()
         assert len(spawned) == 1, "second call must not have spawned a thread"
         assert "exceeded" in str(exc1.value)
-        assert "already in flight" in str(exc2.value)
+        assert "exceeded" in str(exc2.value)
         assert self.cls.state_save_timeouts == 2
+
+    @pytest.mark.asyncio
+    async def test_brief_contention_does_not_count_as_timeout(self) -> None:
+        """When a save is in flight but completes within the joiner's budget,
+        the joining call returns successfully without incrementing the
+        timeout counter. Brief overlap is contention, not a real timeout."""
+
+        import threading
+
+        # Block briefly, much shorter than the patched budget. The first
+        # caller spawns and waits past the unblock; the second caller
+        # joins the same task and also sees it complete in time.
+        unblock = threading.Event()
+        spawned: list[int] = []
+
+        def briefly_slow_save() -> None:
+            spawned.append(1)
+            unblock.wait(timeout=2.0)
+
+        async def release_after_a_bit() -> None:
+            await asyncio.sleep(0.05)
+            unblock.set()
+
+        with patch.object(self.cls, "_save_cache", side_effect=briefly_slow_save):
+            # Budget of 0.5 s comfortably exceeds the 0.05 s block.
+            with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.5):
+                # Spawn caller and joiner concurrently with a delayed unblock.
+                releaser = asyncio.create_task(release_after_a_bit())
+                # Both calls succeed once the thread unblocks; neither
+                # exceeds its 0.5 s budget.
+                await asyncio.gather(
+                    self.cls.save_cache(),
+                    self.cls.save_cache(),
+                )
+                await releaser
+
+        assert len(spawned) == 1, "second call must not have spawned a thread"
+        assert (
+            self.cls.state_save_timeouts == 0
+        ), "brief contention must not count as timeout"
 
     @pytest.mark.asyncio
     async def test_no_slack_handler_does_not_error(self) -> None:

--- a/tests/models/test_machine_state.py
+++ b/tests/models/test_machine_state.py
@@ -607,6 +607,41 @@ class TestAsyncSaveCache(MachineStateTester):
         assert "2" in kwargs["text"]
 
     @pytest.mark.asyncio
+    async def test_single_flight_fails_fast_when_save_in_progress(self) -> None:
+        """A second call while the first is still running fails immediately
+        instead of spawning another thread (preventing pool exhaustion)."""
+
+        # Use a real Event so the underlying thread blocks deterministically
+        # and we can assert that no second thread was spawned.
+        import threading
+
+        block_thread = threading.Event()
+        spawned: list[int] = []
+
+        def slow_save() -> None:
+            spawned.append(1)
+            block_thread.wait(timeout=5.0)
+
+        m_app = MagicMock()
+        m_app.config = {}
+        with patch(f"{pbm}.current_app", new=m_app):
+            with patch.object(self.cls, "_save_cache", side_effect=slow_save):
+                with patch(f"{pbm}.STATE_SAVE_TIMEOUT_SEC", 0.05):
+                    # First call hits the budget timeout while the thread blocks
+                    with pytest.raises(StateSaveTimeoutError) as exc1:
+                        await self.cls.save_cache()
+                    # Second call sees the still-running task and fails-fast
+                    with pytest.raises(StateSaveTimeoutError) as exc2:
+                        await self.cls.save_cache()
+
+        # Release the blocked thread so the test exits cleanly
+        block_thread.set()
+        assert len(spawned) == 1, "second call must not have spawned a thread"
+        assert "exceeded" in str(exc1.value)
+        assert "already in flight" in str(exc2.value)
+        assert self.cls.state_save_timeouts == 2
+
+    @pytest.mark.asyncio
     async def test_no_slack_handler_does_not_error(self) -> None:
         """When SLACK_HANDLER is absent the notify path is silently skipped."""
 

--- a/tests/views/test_machine.py
+++ b/tests/views/test_machine.py
@@ -76,6 +76,35 @@ class TestRouteSpecialCases:
             "argument 'foo'",
         }
 
+    @freeze_time("2023-07-16 03:14:08", tz_offset=0)
+    async def test_state_save_timeout_returns_503(self, tmp_path: Path) -> None:
+        """Verify state-save timeout surfaces as HTTP 503 to firmware."""
+        from dm_mac.models.machine import StateSaveTimeoutError
+
+        app, client = app_and_client(tmp_path)
+        mname: str = "metal-mill"
+        m: Machine = app.config["MACHINES"].machines_by_name[mname]
+
+        async def boom() -> None:
+            m.state.state_save_timeouts += 1
+            raise StateSaveTimeoutError("simulated")
+
+        with patch.object(m.state, "save_cache", side_effect=boom):
+            response: Response = await client.post(
+                "/api/machine/update",
+                json={
+                    "machine_name": mname,
+                    "oops": False,
+                    "rfid_value": "",
+                    "uptime": 12.3,
+                    "wifi_signal_db": -54,
+                    "wifi_signal_percent": 92,
+                    "internal_temperature_c": 53.89,
+                },
+            )
+        assert response.status_code == 503
+        assert await response.json == {"error": "state save timeout"}
+
 
 @freeze_time("2023-07-16 03:14:08", tz_offset=0)
 class TestUpdateNewMachine:
@@ -3317,6 +3346,24 @@ class TestOopsApi:
         # check response
         assert response.status_code == 500
 
+    async def test_oops_state_save_timeout(self, tmp_path: Path) -> None:
+        """Test oops POST returns 503 on state-save timeout."""
+        from dm_mac.models.machine import StateSaveTimeoutError
+
+        app, client = app_and_client(tmp_path)
+        mname: str = "metal-mill"
+        m: Machine = app.config["MACHINES"].machines_by_name[mname]
+
+        async def boom() -> None:
+            raise StateSaveTimeoutError("simulated")
+
+        with patch.object(m.state, "save_cache", side_effect=boom):
+            response: Response = await client.post(
+                "/api/machine/oops/metal-mill",
+            )
+        assert response.status_code == 503
+        assert await response.json == {"error": "state save timeout"}
+
 
 @freeze_time("2023-07-16 03:14:08", tz_offset=0)
 class TestLockApi:
@@ -3408,6 +3455,24 @@ class TestLockApi:
         )
         # check response
         assert response.status_code == 500
+
+    async def test_lockout_state_save_timeout(self, tmp_path: Path) -> None:
+        """Test locked_out POST returns 503 on state-save timeout."""
+        from dm_mac.models.machine import StateSaveTimeoutError
+
+        app, client = app_and_client(tmp_path)
+        mname: str = "metal-mill"
+        m: Machine = app.config["MACHINES"].machines_by_name[mname]
+
+        async def boom() -> None:
+            raise StateSaveTimeoutError("simulated")
+
+        with patch.object(m.state, "save_cache", side_effect=boom):
+            response: Response = await client.post(
+                "/api/machine/locked_out/metal-mill",
+            )
+        assert response.status_code == 503
+        assert await response.json == {"error": "state save timeout"}
 
 
 @freeze_time("2023-07-16 03:14:08", tz_offset=0)

--- a/tests/views/test_machine.py
+++ b/tests/views/test_machine.py
@@ -3347,7 +3347,12 @@ class TestOopsApi:
         assert response.status_code == 500
 
     async def test_oops_state_save_timeout(self, tmp_path: Path) -> None:
-        """Test oops POST returns 503 on state-save timeout."""
+        """Test oops POST returns 503 on state-save timeout.
+
+        Body must include ``action_applied: true`` so the API caller
+        knows the in-memory state mutation took effect even though
+        persistence to disk timed out.
+        """
         from dm_mac.models.machine import StateSaveTimeoutError
 
         app, client = app_and_client(tmp_path)
@@ -3362,7 +3367,10 @@ class TestOopsApi:
                 "/api/machine/oops/metal-mill",
             )
         assert response.status_code == 503
-        assert await response.json == {"error": "state save timeout"}
+        assert await response.json == {
+            "error": "state save timeout",
+            "action_applied": True,
+        }
 
 
 @freeze_time("2023-07-16 03:14:08", tz_offset=0)
@@ -3457,7 +3465,12 @@ class TestLockApi:
         assert response.status_code == 500
 
     async def test_lockout_state_save_timeout(self, tmp_path: Path) -> None:
-        """Test locked_out POST returns 503 on state-save timeout."""
+        """Test locked_out POST returns 503 on state-save timeout.
+
+        Body must include ``action_applied: true`` so the API caller
+        knows the in-memory lock/unlock mutation took effect even
+        though persistence to disk timed out.
+        """
         from dm_mac.models.machine import StateSaveTimeoutError
 
         app, client = app_and_client(tmp_path)
@@ -3472,7 +3485,10 @@ class TestLockApi:
                 "/api/machine/locked_out/metal-mill",
             )
         assert response.status_code == 503
-        assert await response.json == {"error": "state save timeout"}
+        assert await response.json == {
+            "error": "state save timeout",
+            "action_applied": True,
+        }
 
 
 @freeze_time("2023-07-16 03:14:08", tz_offset=0)

--- a/tests/views/test_prometheus.py
+++ b/tests/views/test_prometheus.py
@@ -263,6 +263,14 @@ class TestPrometheus:
         machine_status_led{display_name="always-on-machine",led_attribute="green",machine_name="always-on-machine"} 0.0
         machine_status_led{display_name="always-on-machine",led_attribute="blue",machine_name="always-on-machine"} 0.0
         machine_status_led{display_name="always-on-machine",led_attribute="brightness",machine_name="always-on-machine"} 0.0
+        # HELP mac_state_save_timeouts_total Lifetime count of state-save timeouts (>2.0s) for the machine
+        # TYPE mac_state_save_timeouts_total counter
+        mac_state_save_timeouts_total{display_name="Metal Mill",machine_name="metal-mill"} 0.0
+        mac_state_save_timeouts_total{display_name="hammer",machine_name="hammer"} 0.0
+        mac_state_save_timeouts_total{display_name="permissive-lathe",machine_name="permissive-lathe"} 0.0
+        mac_state_save_timeouts_total{display_name="restrictive-lathe",machine_name="restrictive-lathe"} 0.0
+        mac_state_save_timeouts_total{display_name="esp32test",machine_name="esp32test"} 0.0
+        mac_state_save_timeouts_total{display_name="always-on-machine",machine_name="always-on-machine"} 0.0
         """  # noqa: E501
         ).replace("__FILE_MTIME__", actual_mtime_str)
         assert custom_metrics == expected
@@ -455,6 +463,14 @@ class TestPrometheus:
         machine_status_led{display_name="always-on-machine",led_attribute="green",machine_name="always-on-machine"} 0.0
         machine_status_led{display_name="always-on-machine",led_attribute="blue",machine_name="always-on-machine"} 0.0
         machine_status_led{display_name="always-on-machine",led_attribute="brightness",machine_name="always-on-machine"} 0.0
+        # HELP mac_state_save_timeouts_total Lifetime count of state-save timeouts (>2.0s) for the machine
+        # TYPE mac_state_save_timeouts_total counter
+        mac_state_save_timeouts_total{display_name="Metal Mill",machine_name="metal-mill"} 0.0
+        mac_state_save_timeouts_total{display_name="hammer",machine_name="hammer"} 0.0
+        mac_state_save_timeouts_total{display_name="permissive-lathe",machine_name="permissive-lathe"} 0.0
+        mac_state_save_timeouts_total{display_name="restrictive-lathe",machine_name="restrictive-lathe"} 0.0
+        mac_state_save_timeouts_total{display_name="esp32test",machine_name="esp32test"} 0.0
+        mac_state_save_timeouts_total{display_name="always-on-machine",machine_name="always-on-machine"} 0.0
         """  # noqa: E501
         ).replace("__FILE_MTIME__", actual_mtime_str)
         assert custom_metrics == expected


### PR DESCRIPTION
## Summary

Closes the failure mode from the **2026-05-05 incident** in which four
ESP32 MCUs (Bronte, Grizzly Metal Lathe, Metal Mill, Resaw) all wedged
within 31 seconds of one another after a single ``POST /api/machine/update``
took 30.6 s to return HTTP 200, and stayed wedged for ~22h57m until each
was power-cycled. Implements every recommendation from the analysis
document (`docs/2026-05-05-mcu-lockup-analysis.md`).

Five layered defenses, applied in priority order so each one reduces
risk monotonically:

| Layer | Where | Reboot risk to active cut |
|---|---|---|
| **§7** server-side disk-write timeout → HTTP 503 | server | none |
| **§2** ``http_request: timeout: 5s`` + ``watchdog_timeout: 8s`` | firmware | none |
| **§4** ``on_error`` failure tracking (no reboot from this path) | firmware | none |
| **§5** dedupe 5 inline POST blocks → ``script: post_to_mac`` | firmware | none |
| **§1** liveness watchdog **gated on relay state** | firmware | none under normal operation |
| **§3** esp-idf task WDT panic at 60 s | firmware | very rare; catastrophic-hang only |

## What's in the PR

- **Server (Milestone 1):** ``MachineState.save_cache()`` async wrapper bounds
  pickle writes to ``STATE_SAVE_TIMEOUT_SEC`` (2.0 s); on overrun the three
  state-mutating endpoints return ``503 {"error": "state save timeout"}``.
  Per-machine ``state_save_timeouts`` counter, exposed as
  ``mac_state_save_timeouts_total`` Prometheus counter; Slack notification
  fires only when the per-machine count crosses ≥ 2 (single transient
  stalls don't page).
- **Firmware (Milestones 2–4):** five duplicated ``http_request.post`` blocks
  in ``esphome-configs/2025.11.2/no-current-input.yaml`` collapse into a
  single ``script: post_to_mac`` (``mode: restart``). Per-request HTTP
  timeout / watchdog_timeout. Status-code-aware ``on_response`` (so HTTP
  503 from the server-side path correctly increments
  ``consecutive_post_failures``). New 30 s liveness watchdog interval that
  reboots only when no relay is energized and shows ``WARN: server\nlink
  stale`` on the LCD when a relay is on, so an in-progress laser cut is
  never interrupted. esp-idf task WDT configured with 60 s timeout +
  ``CONFIG_ESP_TASK_WDT_PANIC=y`` as a catastrophic-hang fallback.
- **Docs (Milestone 5):** ``CLAUDE.md`` and ``docs/source/http-api.rst``
  updated. New ``docs/2026-05-05-mcu-lockup-analysis.md`` captures the
  full incident root-cause + bug references (ESPHome #6677, #2501,
  esp-idf #12578, etc.).
- **Tests:** new ``TestAsyncSaveCache`` class (5 tests) covers the timeout
  raise, no-Slack-on-1st, Slack-on-2nd, and missing-handler paths. New
  503 surfacing tests for ``/machine/update``, ``/machine/oops``,
  ``/machine/locked_out``. Prometheus expected-output tests regenerated
  for the new counter. All 280 tests pass; 97 % coverage; mypy /
  pre-commit / safety / docs all green.

Net firmware change: 431 → 325 lines (~25 % smaller despite adding
liveness logic, on_error handling, and sdkconfig overrides) — the five
copy-pasted POST blocks collapse into one.

## Test plan

- [x] ``nox -s tests`` — all passing, 97 % coverage
- [x] ``nox -s mypy`` — clean
- [x] ``nox -s pre-commit`` — clean
- [x] ``nox -s safety`` — clean
- [x] ``nox -s docs`` — builds clean
- [x] ``esphome config esphome-configs/2025.11.2/no-current-input.yaml``
      validates (ESPHome 2025.6.3 used locally)
- [ ] **Live rollout (Milestone 6, post-merge — operator-driven):**
  - [x] Deploy server-side fix to production; confirm
        ``mac_state_save_timeouts_total`` stays at zero under normal load
  - [x] Flash one MCU first (suggested: Bronte), soak ≥ 24 h
  - [ ] Induced-failure: stop ``mac-server`` with no card inserted →
        firmware reboots within 90–120 s
  - [ ] Induced-failure: stop ``mac-server`` with card inserted (relay
        on) → firmware shows ``WARN: server\nlink stale``, does NOT
        reboot; resumes cleanly when server returns
  - [x] Flash remaining 3 units (Grizzly Metal Lathe, Metal Mill, Resaw)
  - [ ] All 4 units stable for ≥ 7 days; move feature file to
        ``docs/features/completed/`` in a follow-up commit

## See also

- Incident root-cause analysis: ``docs/2026-05-05-mcu-lockup-analysis.md``
- Feature plan: ``docs/features/mcu-heartbeat-resilience.md``

🤖 Generated with [Claude Code](https://claude.com/claude-code)