### PR TITLE
Re-point ownership references from jantman to Decaturmakers org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           name: Release ${{ github.ref_name }}
           body: |
             Release ${{ github.ref_name }}.
-            Docker images: https://github.com/users/jantman/packages/container/package/machine-access-control
+            Docker images: https://github.com/orgs/Decaturmakers/packages/container/package/machine-access-control
             Python packages: https://pypi.org/project/machine_access_control/
           draft: false
           prerelease: false

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ Decatur Makers Machine Access Control (dm-mac)
 .. image:: https://www.repostatus.org/badges/latest/concept.svg
    :alt: Project Status: Concept – Minimal or no implementation has been done yet, or the repository is only intended to be a limited example, demo, or proof-of-concept.
    :target: https://www.repostatus.org/#concept
-.. image:: https://github.com/jantman/machine-access-control/actions/workflows/tests.yml/badge.svg
-   :target: https://github.com/jantman/machine-access-control/actions/workflows/tests.yml
+.. image:: https://github.com/Decaturmakers/machine-access-control/actions/workflows/tests.yml/badge.svg
+   :target: https://github.com/Decaturmakers/machine-access-control/actions/workflows/tests.yml
 
 This is a software and hardware project for using RFID cards/fobs to
 control use of various power tools and equipment in the `Decatur
@@ -19,11 +19,11 @@ the `Neon CRM <https://www.neoncrm.com/>`__ as its source for user data,
 though that is completely optional and pluggable.
 
 For full documentation, see:
-https://jantman.github.io/machine-access-control/
+https://decaturmakers.github.io/machine-access-control/
 
 License
 -------
 
 Distributed under the terms of the `MIT
-license <https://github.com/jantman/machine_access_control/blob/main/LICENSE>`__,
+license <https://github.com/Decaturmakers/machine-access-control/blob/main/LICENSE>`__,
 *Machine_Access_Control* (``dm_mac``) is free and open source software.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,7 +19,7 @@ export GIT_COMMIT := $(shell git rev-parse --short HEAD)
 export GITURL := $(shell git config remote.origin.url)
 export BRANCH_NAME := $(shell git rev-parse --abbrev-ref HEAD)
 # TODO: update the proper git URL here:
-ifneq "$(GITURL)" "git@github.com:jantman/machine-access-control.git"
+ifneq "$(GITURL)" "git@github.com:Decaturmakers/machine-access-control.git"
 	export GIT_COMMIT := ${GIT_COMMIT} (branch '${BRANCH_NAME}' from $(GITURL))
 endif
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -11,10 +11,10 @@ requests.
 
 Here is a list of important resources for contributors:
 
--  `Source Code <https://github.com/jantman/machine_access_control>`__
--  `Documentation <https://github.com/jantman/machine_access_control>`__
+-  `Source Code <https://github.com/Decaturmakers/machine-access-control>`__
+-  `Documentation <https://github.com/Decaturmakers/machine-access-control>`__
 -  `Issue
-   Tracker <https://github.com/jantman/machine_access_control/issues>`__
+   Tracker <https://github.com/Decaturmakers/machine-access-control/issues>`__
 
 Tooling in use
 --------------
@@ -111,7 +111,7 @@ How to submit changes
 ---------------------
 
 Open a `pull
-request <https://github.com/jantman/machine_access_control/pulls>`__ to
+request <https://github.com/Decaturmakers/machine-access-control/pulls>`__ to
 submit changes to this project.
 
 Your pull request needs to meet the following guidelines for acceptance:
@@ -138,4 +138,4 @@ your approach.
 Release Process
 ---------------
 
-Use ``poetry version`` to increment the version number, commit push and merge that. Tag the repo and push the tag. `GitHub Actions <https://github.com/jantman/machine-access-control/actions>`__ will run a Docker build, push to GHCR (GitHub Container Registry), build to PyPI, and create a release on the repo.
+Use ``poetry version`` to increment the version number, commit push and merge that. Tag the repo and push the tag. `GitHub Actions <https://github.com/Decaturmakers/machine-access-control/actions>`__ will run a Docker build, push to GHCR (GitHub Container Registry), build to PyPI, and create a release on the repo.

--- a/docs/source/grafana-dashboard.json
+++ b/docs/source/grafana-dashboard.json
@@ -1817,7 +1817,7 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Machine Access Control",
-  "description": "https://github.com/jantman/machine-access-control/blob/main/docs/source/grafana-dashboard.json",
+  "description": "https://github.com/Decaturmakers/machine-access-control/blob/main/docs/source/grafana-dashboard.json",
   "uid": "dm-mac-dashboard",
   "version": 1,
   "weekStart": ""

--- a/docs/source/grafana-dashboard.md
+++ b/docs/source/grafana-dashboard.md
@@ -5,7 +5,7 @@
 This document provides comprehensive information about the Grafana dashboard for the Decatur Makers Machine Access Control (dm-mac) system. This dashboard visualizes metrics exposed by the `/metrics` Prometheus endpoint on the control server.
 
 **Dashboard File**: `docs/source/grafana-dashboard.json`
-**GitHub URL**: https://github.com/jantman/machine-access-control/blob/main/docs/source/grafana-dashboard.json
+**GitHub URL**: https://github.com/Decaturmakers/machine-access-control/blob/main/docs/source/grafana-dashboard.json
 **Documentation**: `docs/source/admin.rst` (includes embedded dashboard JSON)
 
 ## Purpose
@@ -500,5 +500,5 @@ When modifying the dashboard:
 - **Prometheus Querying**: https://prometheus.io/docs/prometheus/latest/querying/basics/
 - **PromQL Functions**: https://prometheus.io/docs/prometheus/latest/querying/functions/
 - **Grafana Panel Types**: https://grafana.com/docs/grafana/latest/panels-visualizations/
-- **Project Repository**: https://github.com/jantman/machine-access-control
+- **Project Repository**: https://github.com/Decaturmakers/machine-access-control
 - **Metrics Implementation**: `src/dm_mac/views/prometheus.py`

--- a/docs/source/hardware.rst
+++ b/docs/source/hardware.rst
@@ -125,7 +125,7 @@ The following table lists the components required for the Version 1 MCU hardware
 Wiring
 ++++++
 
-This is intended to work with `https://github.com/jantman/machine-access-control/blob/main/esphome-configs/2024.6.4/no-current-input.yaml </https://github.com/jantman/machine-access-control/blob/main/esphome-configs/2024.6.4/no-current-input.yaml>`__. Note that a standalone (non-networked) ESPHome configuration for verifying the operation of all hardware, along with instructions for using it, can be found in `https://github.com/jantman/machine-access-control/tree/main/esphome-configs/2025.11.2 <https://github.com/jantman/machine-access-control/tree/main/esphome-configs/2025.11.2>`__.
+This is intended to work with `https://github.com/Decaturmakers/machine-access-control/blob/main/esphome-configs/2024.6.4/no-current-input.yaml </https://github.com/Decaturmakers/machine-access-control/blob/main/esphome-configs/2024.6.4/no-current-input.yaml>`__. Note that a standalone (non-networked) ESPHome configuration for verifying the operation of all hardware, along with instructions for using it, can be found in `https://github.com/Decaturmakers/machine-access-control/tree/main/esphome-configs/2025.11.2 <https://github.com/Decaturmakers/machine-access-control/tree/main/esphome-configs/2025.11.2>`__.
 
 .. image:: ../../hardware/v1_mcu/Hardware_v1.png
    :alt: Wiring diagram of system
@@ -192,14 +192,14 @@ This is intended to work with `https://github.com/jantman/machine-access-control
 Enclosure
 +++++++++
 
-There is an example enclosure for the unit, 3D printed with a few laser cut parts, in `the hardware/v1_mcu directory of the GitHub repo <https://github.com/jantman/machine-access-control/tree/main/hardware/v1_mcu>`__. See that directory for information on fabrication and assembly.
+There is an example enclosure for the unit, 3D printed with a few laser cut parts, in `the hardware/v1_mcu directory of the GitHub repo <https://github.com/Decaturmakers/machine-access-control/tree/main/hardware/v1_mcu>`__. See that directory for information on fabrication and assembly.
 
 .. _hardware.esphome-configs:
 
 ESPHome Configurations
 ----------------------
 
-Example ESPHome configurations for various ESPHome versions and various hardware combinations can be found in the `esphome-configs/ directory of the git repo <https://github.com/jantman/machine-access-control/tree/main/esphome-configs>`__ broken down by ESPHome version. New installations should always use the newest supported ESPHome version, as bug fixes and features are not backported to earlier versions of these configs.
+Example ESPHome configurations for various ESPHome versions and various hardware combinations can be found in the `esphome-configs/ directory of the git repo <https://github.com/Decaturmakers/machine-access-control/tree/main/esphome-configs>`__ broken down by ESPHome version. New installations should always use the newest supported ESPHome version, as bug fixes and features are not backported to earlier versions of these configs.
 
 All of the example ESPHome configurations begin with a ``substitutions`` key, which contains a ``machine_name`` substitution. This must be set to the same name as used in the :ref:`configuration.machines-json` config file. If desired, you can override the ``esphome`` ``name`` and ``friendly_name`` values (though this is not recommended).
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,7 +7,7 @@ The only supported method of installing and running the Control Server is via Do
 
 For actual use, you will need to ensure that the Docker container is always running and restarts automatically; it's assumed that you'll use systemd or some configuration management / automation tool for that, but that's outside the scope of this documentation.
 
-The `tests/fixtures directory of the source repository <https://github.com/jantman/machine-access-control/tree/main/tests/fixtures>`__ contains an example `docker-compose <https://docs.docker.com/compose/>`__ file that can be used as an example of how to run the container. By default, it will be accessible on port 5000 unless that file is changed.
+The `tests/fixtures directory of the source repository <https://github.com/Decaturmakers/machine-access-control/tree/main/tests/fixtures>`__ contains an example `docker-compose <https://docs.docker.com/compose/>`__ file that can be used as an example of how to run the container. By default, it will be accessible on port 5000 unless that file is changed.
 
 **NOTE** that by default the container runs as root, and files written by it (i.e. the machine state directory) will be root-owned.
 

--- a/hardware/v1_mcu/README.md
+++ b/hardware/v1_mcu/README.md
@@ -1,6 +1,6 @@
 # machine-access-control hardware/v1_mcu
 
-This directory holds information related to the Version 1 Machine Control Unit (MCU) hardware, mainly the designs for the 3D printed enclosure and laser-cut acrylic RFID card/fob holder, as well as the wiring diagram (such as it is). Full details of the electronic components and wiring can be seen in the documentation at https://jantman.github.io/machine-access-control/hardware.html#version-1-hardware
+This directory holds information related to the Version 1 Machine Control Unit (MCU) hardware, mainly the designs for the 3D printed enclosure and laser-cut acrylic RFID card/fob holder, as well as the wiring diagram (such as it is). Full details of the electronic components and wiring can be seen in the documentation at https://decaturmakers.github.io/machine-access-control/hardware.html#version-1-hardware
 
 ## RFID Card / Fob Holder
 
@@ -14,7 +14,7 @@ The enclosure is designed to be 3D printed; prototypes were printed on a (highly
 
 I'm slicing with Cura. If the mounting nut catches are enabled, be sure to enable supports and also set your wall line width, initial layer height, and layer height in [config.scad](config.scad).
 
-The connector used for power and control is a GX16-8 style round connector as specified in the [documentation](https://jantman.github.io/machine-access-control/hardware.html#version-1-hardware) and mounts using a single round through-hole of at least 0.615 inches (nominally 5/8" or 16mm). Due to the wide variety of mounting options, this hole is left out of the model and can be drilled after printing in whichever location is most suitable for the final mounting.
+The connector used for power and control is a GX16-8 style round connector as specified in the [documentation](https://decaturmakers.github.io/machine-access-control/hardware.html#version-1-hardware) and mounts using a single round through-hole of at least 0.615 inches (nominally 5/8" or 16mm). Due to the wide variety of mounting options, this hole is left out of the model and can be drilled after printing in whichever location is most suitable for the final mounting.
 
 ### Required Hardware
 
@@ -51,4 +51,4 @@ See the hardware docs for details.
 
 ### Enclosure Notes
 
-The enclosure itself is built using v3 of [Willem Aandewiel](https://willem.aandewiel.nl/)'s excellent [YAPP_Box](https://github.com/mrWheel/YAPP_Box) OpenSCAD enclosure generator, with a [patch](https://github.com/jantman/machine-access-control/commit/c860e23d8b0bcd43c924b47d14e1e0748aece98f) for custom cutouts.
+The enclosure itself is built using v3 of [Willem Aandewiel](https://willem.aandewiel.nl/)'s excellent [YAPP_Box](https://github.com/mrWheel/YAPP_Box) OpenSCAD enclosure generator, with a [patch](https://github.com/Decaturmakers/machine-access-control/commit/c860e23d8b0bcd43c924b47d14e1e0748aece98f) for custom cutouts.

--- a/hardware/v1_mcu/gx16-8.scad
+++ b/hardware/v1_mcu/gx16-8.scad
@@ -1,4 +1,4 @@
-// FROM: https://github.com/jantman/machine-access-control ; MIT license
+// FROM: https://github.com/Decaturmakers/machine-access-control ; MIT license
 // dimensioned in inches
 $fn = 360;
 

--- a/hardware/v1_mcu/neopixel.scad
+++ b/hardware/v1_mcu/neopixel.scad
@@ -1,4 +1,4 @@
-// FROM: https://github.com/jantman/machine-access-control ; MIT license
+// FROM: https://github.com/Decaturmakers/machine-access-control ; MIT license
 // dimensioned in inches
 $fn = 360;
 

--- a/hardware/v1_mcu/oops_button.scad
+++ b/hardware/v1_mcu/oops_button.scad
@@ -1,4 +1,4 @@
-// FROM: https://github.com/jantman/machine-access-control ; MIT license
+// FROM: https://github.com/Decaturmakers/machine-access-control ; MIT license
 // dimensioned in inches
 $fn = 360;
 

--- a/hardware/v1_mcu/relay.scad
+++ b/hardware/v1_mcu/relay.scad
@@ -1,4 +1,4 @@
-// FROM: https://github.com/jantman/machine-access-control ; MIT license
+// FROM: https://github.com/Decaturmakers/machine-access-control ; MIT license
 // dimensioned in inches
 $fn = 360;
 

--- a/hardware/v1_mcu/rfid.scad
+++ b/hardware/v1_mcu/rfid.scad
@@ -1,4 +1,4 @@
-// FROM: https://github.com/jantman/machine-access-control ; MIT license
+// FROM: https://github.com/Decaturmakers/machine-access-control ; MIT license
 // dimensioned in inches
 $fn = 360;
 

--- a/hardware/v1_mcu/rfid_holder/README.md
+++ b/hardware/v1_mcu/rfid_holder/README.md
@@ -1,6 +1,6 @@
 # RFID Card/Fob Holder
 
-A holder/pocket for RFID cards and fobs to align and hold them over a RFID reader; designed for [https://github.com/jantman/machine-access-control](https://github.com/jantman/machine-access-control).
+A holder/pocket for RFID cards and fobs to align and hold them over a RFID reader; designed for [https://github.com/Decaturmakers/machine-access-control](https://github.com/Decaturmakers/machine-access-control).
 
 Each unit is made up of one top piece, two symmetrical middle pieces, and two symmetrical bottom pieces. The middle and bottom pieces have a drain channel to allow liquids or debris to drain or be blown out the bottom of the holder. Pieces attach with M4 screws.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,14 @@ requires = [
 
 [tool.poetry]
 name = "machine_access_control"
-version = "0.13.0"
+version = "0.14.0"
 description = "Decatur Makers Machine Access Control package"
 authors = [ "Jason Antman <jason@jasonantman.com>" ]
 license = "MIT"
 readme = "README.rst"
-homepage = "https://github.com/jantman/machine_access_control"
-repository = "https://github.com/jantman/machine_access_control"
-documentation = "https://github.com/jantman/machine_access_control"
+homepage = "https://github.com/Decaturmakers/machine-access-control"
+repository = "https://github.com/Decaturmakers/machine-access-control"
+documentation = "https://github.com/Decaturmakers/machine-access-control"
 packages = [
   { include = "dm_mac", from = "src" },
 ]
@@ -72,7 +72,7 @@ group.dev.dependencies.openpyxl = "^3.1.0"
 scripts.neongetter = "dm_mac.neongetter:main"
 scripts.neon-fob-adder = "dm_mac.neon_fob_adder:main"
 scripts.mac-server = "dm_mac:main"
-urls.Changelog = "https://github.com/jantman/machine_access_control/releases"
+urls.Changelog = "https://github.com/Decaturmakers/machine-access-control/releases"
 
 [tool.isort]
 profile = "black"

--- a/src/dm_mac/slack_handler.py
+++ b/src/dm_mac/slack_handler.py
@@ -85,7 +85,7 @@ class SlackHandler:
     clear a machine, optionally with no machine name to pick one from a menu.
 
     I am Free and Open Source software:
-    https://github.com/jantman/machine-access-control
+    https://github.com/Decaturmakers/machine-access-control
     """).strip()
 
     def __init__(self, quart_app: Quart):


### PR DESCRIPTION
Prepares the repo for transfer from `github.com/jantman` to `github.com/Decaturmakers`. Merge this **after** transferring the repo so the new links resolve.

## What changed

Rewrote all GitHub-ownership references (repo URLs, GitHub Pages URLs, GHCR package URL) from `jantman` → `Decaturmakers` across:

- **Docs:** `README.rst`, `docs/Makefile`, `docs/source/{contributing,hardware,installation,grafana-dashboard.md}.rst`, `docs/source/grafana-dashboard.json`
- **Hardware:** `hardware/v1_mcu/README.md`, `hardware/v1_mcu/rfid_holder/README.md`, and the 5 `.scad` header comments
- **Code:** `src/dm_mac/slack_handler.py` help-text link
- **CI:** `.github/workflows/release.yml` — switched the Docker-images link from the user-packages form (`/users/jantman/packages`) to the org form (`/orgs/Decaturmakers/packages`)
- **Packaging:** `pyproject.toml` homepage/repository/documentation/Changelog URLs

Also:
- Normalized the inconsistent underscore repo-URL variant (`machine_access_control`) to the real hyphenated repo name (`machine-access-control`).
- **Version bump:** `0.13.0` → `0.14.0` (minor).

## Intentionally left unchanged

- `util/` links to `jantman/pt-p710bt-label-maker` — a *separate* project, not this repo.
- Author / copyright / `LICENSE` attribution to **Jason Antman** (authorship, not ownership).
- PyPI **package name** `machine_access_control` (distinct from the repo URL).
- Test-fixture sample user data (`preferred_name: "jantman"`, alongside the real name/email) and the historical local dev path in `specs/002-second-relay-support/tasks.md`. Happy to scrub these too if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)