### PR TITLE
Lowercase GHCR image repository name in docker builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Login to GHCR
         run: echo "${{secrets.GITHUB_TOKEN}}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Lowercase image repository name
+        id: image
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
       - name: Docker Build and Push
         uses: docker/build-push-action@v7
         with:
@@ -44,8 +47,8 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ steps.image.outputs.repo }}:${{ github.ref_name }}
+            ghcr.io/${{ steps.image.outputs.repo }}:latest
       - name: Build and publish to pypi
         uses: JRubics/poetry-publish@v2.1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -127,6 +127,9 @@ jobs:
         uses: docker/setup-buildx-action@v4
       - name: Login to GHCR
         run: echo "${{secrets.GITHUB_TOKEN}}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Lowercase image repository name
+        id: image
+        run: echo "repo=${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
       - name: Docker Build
         uses: docker/build-push-action@v7
         with:
@@ -140,4 +143,4 @@ jobs:
             org.opencontainers.image.version=${{ github.ref_name }}
             org.opencontainers.image.revision=${{ github.sha }}
           tags: |
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ steps.image.outputs.repo }}:${{ github.sha }}


### PR DESCRIPTION
## Problem

The Docker test build is failing on `main` after the org transfer:

```
ERROR: failed to build: invalid tag
"ghcr.io/DecaturMakers/machine-access-control:1b48d748...":
repository name must be lowercase
```

The `DecaturMakers` org name has an uppercase letter, but Docker/GHCR repository names must be lowercase. The workflows built image tags directly from `${{ github.repository }}`, which carries the uppercase org name.

## Fix

Add a step that lowercases `$GITHUB_REPOSITORY` via bash parameter expansion (`${GITHUB_REPOSITORY,,}`) and reference its output in the `ghcr.io/...` tags, in both:

- `tests.yml` — the `docker` job (SHA-tagged build)
- `release.yml` — the publish job (`:<tag>` and `:latest`)

The OCI image **labels** (`org.opencontainers.image.url`/`source`) are left as-is since they're GitHub URLs and case-insensitive.

## Notes

- No documentation references the GHCR image path explicitly (no `docker pull ghcr.io/...` in docs/README/compose), so no docs change is needed. The published image will be `ghcr.io/decaturmakers/machine-access-control` (lowercase).
- This needs to merge **before** the `0.14.0` tag is pushed, since the release build is triggered by the tag and reads `release.yml` from the tagged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)